### PR TITLE
Add functionality to retrieve metadata from Digital Object

### DIFF
--- a/lib/hyacinth/ezid/hyacinth_metadata_retrieval.rb
+++ b/lib/hyacinth/ezid/hyacinth_metadata_retrieval.rb
@@ -1,0 +1,99 @@
+# Following module contains functionality to retrieve metadata
+# from the dynamic_field_data hash (which is an instance variable
+# of DigitalObject)
+module Hyacinth::Ezid
+  class HyacinthMetadataRetrieval
+    attr_reader :creators, :editors, :moderators, :contributors, :subjects_topic
+    def initialize(digital_object_data_arg)
+      # dod is shorthand for digital_object_data
+      @dod = digital_object_data_arg
+      # dfd is shorthand for dynamic_field_data
+      @dfd = @dod['dynamic_field_data']
+      @creators = []
+      @editors = []
+      @moderators = []
+      @contributors = []
+      @subjects_topic = []
+      process_names
+      process_subjects_topic
+    end
+
+    # Following returns the title of an item. NOTE: if ever an item contains
+    # multiple titles, it will only return the first one.
+    def title
+      # concatenates the non sort portion with the sort portion
+      non_sort_portion = @dfd['title'][0]['title_non_sort_portion'] if @dfd['title'][0].key? 'title_non_sort_portion'
+      sort_portion = @dfd['title'][0]['title_sort_portion']
+      "#{non_sort_portion} #{sort_portion}"
+    end
+
+    # Following returns the abstract of an item. NOTE: if ever an item contains
+    # multiple abstracts, it will only return the first one.
+    def abstract
+      @dfd['abstract'][0]['abstract_value'] if @dfd.key? 'abstract'
+    end
+
+    # Following returns the type of resource for an item.
+    def type_of_resource
+      @dfd['type_of_resource'][0]['type_of_resource_value'] if @dfd.key? 'type_of_resource'
+    end
+
+    # Following returns the starting year of the Date Issued field.
+    # Date is encoded using w3cdtf, so year is always present at start of date
+    def date_issued_start_year
+      @dfd['date_issued'][0]['date_issued_start_value'][0..3] if @dfd.key? 'date_issued'
+    end
+
+    # Following returns the date of the created field. Timestamp is encoded using w3cdtf,
+    # so date in YYYY-MM-DD is always present at start of the timestamp string
+    def date_created
+      @dod['created'][0..9]
+    end
+
+    # Following returns the date of the modified field. Timestamp is encoded using w3cdtf,
+    # so date in YYYY-MM-DD is always present at start of the timestamp string
+    def date_modified
+      @dod['modified'][0..9]
+    end
+
+    def parent_publication_issn
+      @dfd['parent_publication'][0]['parent_publication_issn'] if @dfd.key? 'parent_publication'
+    end
+
+    def parent_publication_isbn
+      @dfd['parent_publication'][0]['parent_publication_isbn'] if @dfd.key? 'parent_publication'
+    end
+
+    def parent_publication_doi
+      @dfd['parent_publication'][0]['parent_publication_doi'] if @dfd.key? 'parent_publication'
+    end
+
+    def doi_identifier
+      @dfd['doi_identifier'][0]['doi_identifier_value'] if @dfd.key? 'doi_identifier'
+    end
+
+    def handle_net_identifier
+      @dfd['cnri_handle_identifier'][0]['cnri_handle_identifier_value'] if @dfd.key? 'cnri_handle_identifier'
+    end
+
+    def process_names
+      @dfd['name'].each do |name|
+        name['name_role'].each do |role|
+          role_value = role['name_role_term']['value'].downcase
+          case role_value
+          when 'author' then @creators << name['name_term']['value']
+          when 'editor' then @editors << name['name_term']['value']
+          when 'moderator' then @moderators << name['name_term']['value']
+          when 'contributor' then @contributors << name['name_term']['value']
+          end
+        end
+      end
+    end
+
+    def process_subjects_topic
+      @dfd['subject_topic'].each do |topic|
+        @subjects_topic << topic['subject_topic_term']['value']
+      end
+    end
+  end
+end

--- a/spec/fixtures/lib/hyacinth/ezid/ezid_item.json
+++ b/spec/fixtures/lib/hyacinth/ezid/ezid_item.json
@@ -1,0 +1,237 @@
+{
+    "identifiers" : ["item.001"]
+    ,
+    "digital_object_type" :
+    {
+	"string_key" : "item"
+    }
+    ,
+    "created" : "2015-02-04T19:22:37.000Z"
+    ,
+    "modified" : "2016-03-31T20:52:23.000Z"
+    ,
+    "project" :
+    {
+	"string_key" : "test"
+    }
+    ,
+    "publish_targets" :
+    [
+	{
+            "string_key" : "test_publish_target_1"
+	}
+	,
+	{
+            "string_key" : "test_publish_target_2"
+	}
+    ]
+    ,
+    "dynamic_field_data" :
+    {
+	"title" :
+	[
+            {
+		"title_sort_portion" : "Catcher in the Rye",
+		"title_non_sort_portion" : "The"
+            }
+	]
+	,
+	"doi_identifier" :
+	[
+	    {
+		"doi_identifier_value" : "10.1371/journal.pone.0119638"
+	    }
+	]
+	,
+	"cnri_handle_identifier" :
+	[
+	    {
+		"cnri_handle_identifier_value" : "http://hdl.handle.net/10022/AC:P:29183"
+	    }
+	]
+	,
+	"type_of_resource" :
+	[
+	    {
+		"type_of_resource_value" : "still image"
+	    }
+	]
+	,
+	"abstract" :
+	[
+            {
+		"abstract_value" : "This is an abstract; yes, a very nice abstract"
+            }
+	]
+	,
+	"name" :
+	[
+            {
+		"name_term" :
+		{
+		    "value" : "Salinger, J. D.",
+		    "uri" : "http://id.loc.gov/authorities/names/n50016589",
+		    "name_type" : "personal"
+		}
+		,
+		"name_role" :
+		[
+		    {
+			"name_role_term" :
+			{
+			    "value" : "Author",
+			    "uri" : "http://id.loc.gov/vocabulary/relators/aut"
+			}
+		    }
+		]
+            }
+	    ,
+            {
+		"name_term" :
+		{
+		    "value" : "Picasso González, Juan",
+		    "uri" : "http://id.loc.gov/authorities/names/n2003054176.html",
+		    "name_type" : "personal"
+		}
+		,
+		"name_role" :
+		[
+		    {
+			"name_role_term" :
+			{
+			    "value" : "Illustrator",
+			    "uri" : "http://id.loc.gov/vocabulary/relators/ill"
+			}
+		    }
+		]
+            }
+	    ,
+            {
+		"name_term" :
+		{
+		    "value" : "Lincoln, Abraham",
+		    "uri" : "http://id.loc.gov/authorities/names/n79006779",
+		    "name_type" : "personal"
+		}
+		,
+		"name_role" :
+		[
+		    {
+			"name_role_term" :
+			{
+			    "value" : "author",
+			    "uri" : "http://id.loc.gov/vocabulary/relators/aut"
+			}
+		    }
+		    ,
+		    {
+			"name_role_term" :
+			{
+			    "value" : "Editor",
+			    "uri" : "http://id.loc.gov/vocabulary/relators/edt"
+			}
+		    }
+		]
+            }
+	    ,
+	    {
+		"name_term" : 
+		{
+		    "uri" : "temp:ea1cc077df24fbc74a96019811e6546692848b85a63cf6189c3d45b7bbdeaf17",
+		    "value" : "Columbia University. English and Comparative Literature",
+		    "name_type" : "corporate"
+		}
+		,
+		"name_role":
+		[
+		    {
+			"name_role_term":
+			{
+			    "uri": "http://id.loc.gov/vocabulary/relators/org",
+			    "value": "Originator"
+			}
+		    }
+		]
+	    }
+	]
+	,
+	"subject_topic" :
+	[
+	    {
+		"subject_topic_term" :
+		{
+		    "uri" : "http://id.worldcat.org/fast/872451",
+		    "value" : "Computer science",
+		    "type" : "external",
+		    "vocabulary_string_key" : "subject_topic",
+		    "internal_id" : 195965
+		}
+	    }
+	    ,
+	    {
+		"subject_topic_term" :
+		{
+		    "uri" : "http://experimental.worldcat.org/fast/873333",
+		    "value" : "Concertos (Flute)",
+		    "type" : "external",
+		    "vocabulary_string_key" : "subject_topic",
+		    "internal_id" : 195966
+		}
+	    }
+	]
+	,
+	"date_issued" :
+	[
+	    {
+		"date_issued_start_value" : "2015-01-01"
+	    }
+	]
+	,
+	"parent_publication" :
+	[
+	    {
+		"parent_publication_issn" : "1932-6203",
+		"parent_publication_isbn" : "0670734608",
+		"parent_publication_volume" : "10",
+		"parent_publication_issue" : "3",
+		"parent_publication_publisher" : "PLoS ONE",
+		"parent_publication_doi" : "10.1371/journal.pone.0119638"
+	    }
+	]
+	,
+	"subject_topic" :
+	[
+	    {
+		"subject_topic_term" :
+		{
+		    "uri" : "http://id.worldcat.org/fast/1737284",
+		    "value" : "Educational attainment",
+		    "type" : "external",
+		    "vocabulary_string_key" : "subject_topic",
+		    "internal_id" : 195775
+		}
+	    },
+	    {
+		"subject_topic_term" :
+		{
+		    "uri" : "http://id.worldcat.org/fast/1053367",
+		    "value" : "Parental influences",
+		    "type" : "external",
+		    "vocabulary_string_key" : "subject_topic",
+		    "internal_id" : 195776
+		}
+	    }
+	    ,
+	    {
+		"subject_topic_term":
+		{
+		    "uri" : "http://id.worldcat.org/fast/1026881",
+		    "value" : "Mother and child--Psychological aspects",
+		    "type" : "external",
+		    "vocabulary_string_key" : "subject_topic",
+		    "internal_id" : 195777
+		}
+	    }
+	]
+    }
+}

--- a/spec/unit/hyacinth/ezid/hyacinth_metadata_retrieval_spec.rb
+++ b/spec/unit/hyacinth/ezid/hyacinth_metadata_retrieval_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+describe Hyacinth::Ezid::HyacinthMetadataRetrieval do
+
+  let(:dod) {
+    data = JSON.parse( fixture('lib/hyacinth/ezid/ezid_item.json').read )
+    data['identifiers'] = ['item.' + SecureRandom.uuid] # random identifer to avoid collisions
+    data
+  }
+
+  context "#new:" do
+    it "get title" do
+      local_metadata_retrieval = Hyacinth::Ezid::HyacinthMetadataRetrieval.new dod
+      expected_full_title = 'The Catcher in the Rye'
+      actual_full_title = local_metadata_retrieval.title
+      expect(actual_full_title).to eq(expected_full_title)
+    end
+  end
+
+  context "#abstract:" do
+    it "abstract" do
+      local_metadata_retrieval = Hyacinth::Ezid::HyacinthMetadataRetrieval.new dod
+      expected_abstract = 'This is an abstract; yes, a very nice abstract'
+      actual_abstract = local_metadata_retrieval.abstract
+      expect(actual_abstract).to eq(expected_abstract)
+    end
+  end
+
+  context "#type_of_resource:" do
+    it "type_of_resource" do
+      local_metadata_retrieval = Hyacinth::Ezid::HyacinthMetadataRetrieval.new dod
+      expected_type_of_resource = 'still image'
+      actual_type_of_resource = local_metadata_retrieval.type_of_resource
+      expect(actual_type_of_resource).to eq(expected_type_of_resource)
+    end
+  end
+
+  context "#date_issued_start_year:" do
+    it "date_issued_start_year" do
+      local_metadata_retrieval = Hyacinth::Ezid::HyacinthMetadataRetrieval.new dod
+      expected_date = '2015'
+      actual_date = local_metadata_retrieval.date_issued_start_year
+      expect(actual_date).to eq(expected_date)
+    end
+  end
+
+  context "#parent_publication_issn:" do
+    it "parent_publication_issn" do
+      local_metadata_retrieval = Hyacinth::Ezid::HyacinthMetadataRetrieval.new dod
+      expected_issn = '1932-6203'
+      actual_issn = local_metadata_retrieval.parent_publication_issn
+      expect(actual_issn).to eq(expected_issn)
+    end
+  end
+
+  context "#parent_publication_isbn:" do
+    it "parent_publication_isbn" do
+      local_metadata_retrieval = Hyacinth::Ezid::HyacinthMetadataRetrieval.new dod
+      expected_isbn = '0670734608'
+      actual_isbn = local_metadata_retrieval.parent_publication_isbn
+      expect(actual_isbn).to eq(expected_isbn)
+    end
+  end
+
+  context "#parent_publication_doi:" do
+    it "parent_publication_doi" do
+      local_metadata_retrieval = Hyacinth::Ezid::HyacinthMetadataRetrieval.new dod
+      expected_doi = '10.1371/journal.pone.0119638'
+      actual_doi = local_metadata_retrieval.parent_publication_doi
+      expect(actual_doi).to eq(expected_doi)
+    end
+  end
+
+  context "#doi_identifier" do
+    it "doi_identifier" do
+      local_metadata_retrieval = Hyacinth::Ezid::HyacinthMetadataRetrieval.new dod
+      expected_doi_identifier = '10.1371/journal.pone.0119638'
+      actual_doi_identifier = local_metadata_retrieval.doi_identifier
+      expect(actual_doi_identifier).to eq(expected_doi_identifier)
+    end
+  end
+
+  context "#handle_net_identifier" do
+    it "handle_net_identifier" do
+      local_metadata_retrieval = Hyacinth::Ezid::HyacinthMetadataRetrieval.new dod
+      expected_handle_net_identifier = 'http://hdl.handle.net/10022/AC:P:29183'
+      actual_handle_net_identifier = local_metadata_retrieval.handle_net_identifier
+      expect(actual_handle_net_identifier).to eq(expected_handle_net_identifier)
+    end
+  end
+
+  context "#subject_topic:" do
+    it "subject_topic" do
+      local_metadata_retrieval = Hyacinth::Ezid::HyacinthMetadataRetrieval.new dod
+      expected_subjects_topic = ['Educational attainment','Parental influences','Mother and child--Psychological aspects']
+      actual_subjects_topic = local_metadata_retrieval.subjects_topic
+      expect(actual_subjects_topic).to eq(expected_subjects_topic)
+    end
+  end
+
+  context "#date_created:" do
+    it "date_created" do
+      local_metadata_retrieval = Hyacinth::Ezid::HyacinthMetadataRetrieval.new dod
+      expected_date_created = '2015-02-04'
+      actual_date_created = local_metadata_retrieval.date_created
+      expect(actual_date_created).to eq(expected_date_created)
+    end
+  end
+
+  context "#date_modified:" do
+    it "date_modified" do
+      local_metadata_retrieval = Hyacinth::Ezid::HyacinthMetadataRetrieval.new dod
+      expected_date_modified = '2016-03-31'
+      actual_date_modified = local_metadata_retrieval.date_modified
+      expect(actual_date_modified).to eq(expected_date_modified)
+    end
+  end
+
+  context "#process_names works:" do
+    it "creators set" do
+      local_metadata_retrieval = Hyacinth::Ezid::HyacinthMetadataRetrieval.new dod
+      expected_creators = ['Salinger, J. D.','Lincoln, Abraham']
+      expect(local_metadata_retrieval.creators).to eq(expected_creators)
+    end
+
+    it "editors set" do
+      local_metadata_retrieval = Hyacinth::Ezid::HyacinthMetadataRetrieval.new dod
+      expected_editors = ['Lincoln, Abraham']
+      expect(local_metadata_retrieval.editors).to eq(expected_editors)
+    end
+  end
+end


### PR DESCRIPTION
This adds a level of abstraction between the internal format used
by hyacinth and the ezid code, thus insulating the ezid code from
possible future changes to the internal format of the metadata.
Also, it adds filtering; the predominant case is where ezid only
wants one value from a multi-value field. In most of these cases,
we just return the first value. We also need to filter the names
by role.