### PR TITLE
Add functionality to create datacite metadata; Add doi class.

### DIFF
--- a/lib/hyacinth/ezid/datacite_metadata_builder.rb
+++ b/lib/hyacinth/ezid/datacite_metadata_builder.rb
@@ -1,0 +1,70 @@
+# Following module contains functionality to create the XML
+# containing the metadata, using the datacite metadata scheme
+module Hyacinth::Ezid
+  class DataciteMetadataBuilder
+    def initialize(hyacinth_metadata_retrieval_arg)
+      @hyacinth_metadata_retrieval = hyacinth_metadata_retrieval_arg
+    end
+
+    def datacite_xml
+      builder = Nokogiri::XML::Builder.new do |xml|
+        xml.resource('xmlns' => 'http://datacite.org/schema/kernel-3',
+                     'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+                     'xsi:schemaLocation' => 'http://datacite.org/schema/kernel-3 http://schema.datacite.org/meta/kernel-3/metadata.xsd') do
+          xml.identifier('identifierType' => 'DOI') { xml.text @hyacinth_metadata_retrieval.doi_identifier }
+          xml.titles { xml.title @hyacinth_metadata_retrieval.title } if @hyacinth_metadata_retrieval.title
+          xml.publisher EZID[:ezid_publisher]
+          xml.publicationYear @hyacinth_metadata_retrieval.date_issued_start_year
+          xml.date('dateType' => 'Created') { xml.text @hyacinth_metadata_retrieval.date_created }
+          xml.date('dateType' => 'Updated') { xml.text @hyacinth_metadata_retrieval.date_modified }
+          add_creators xml
+          add_subjects xml
+          add_contributors xml
+          xml.resourceType('resourceTypeGeneral' => @hyacinth_metadata_retrieval.type_of_resource)
+          xml.descriptions { xml.description('descriptionType' => 'Abstract') { xml.text @hyacinth_metadata_retrieval.abstract } }
+          add_related_identifiers xml
+        end
+      end
+      builder.to_xml
+    end
+
+    def add_related_identifiers(xml)
+      xml.relatedIdentifiers do
+        xml.relatedIdentifier('relatedIdentifierType' => 'ISSN',
+                              'relationType' => 'isPartOf') { xml.text @hyacinth_metadata_retrieval.parent_publication_issn }
+        xml.relatedIdentifier('relatedIdentifierType' => 'ISBN',
+                              'relationType' => 'isPartOf') { xml.text @hyacinth_metadata_retrieval.parent_publication_isbn }
+        xml.relatedIdentifier('relatedIdentifierType' => 'DOI',
+                              'relationType' => 'isVariantFormOf') { xml.text @hyacinth_metadata_retrieval.parent_publication_doi }
+      end
+    end
+
+    def add_subjects(xml)
+      xml.subjects do
+        @hyacinth_metadata_retrieval.subjects_topic.each { |topic| xml.subject topic }
+      end unless @hyacinth_metadata_retrieval.subjects_topic.empty?
+    end
+
+    def add_creators(xml)
+      xml.creators do
+        @hyacinth_metadata_retrieval.creators.each do |name|
+          xml.creator { xml.creatorName name }
+        end
+      end
+    end
+
+    def add_contributors(xml)
+      xml.contributors do
+        @hyacinth_metadata_retrieval.editors.each do |name|
+          xml.contributor('contributorType' => 'Editor') { xml.contributorName name }
+        end
+        @hyacinth_metadata_retrieval.moderators.each do |name|
+          xml.contributor('contributorType' => 'Other') { xml.contributorName name }
+        end
+        @hyacinth_metadata_retrieval.contributors.each do |name|
+          xml.contributor('contributorType' => 'Other') { xml.contributorName name }
+        end
+      end
+    end
+  end
+end

--- a/lib/hyacinth/ezid/doi.rb
+++ b/lib/hyacinth/ezid/doi.rb
@@ -1,0 +1,28 @@
+# DESGIN NOTE: Currently, the only required EZID indentifiers are DOIs. ARKs are not currently used
+# Therefore, only the current class is implemented. However, if ARKs or URNs are implemented
+# at a later date, the common functionality can be moved to parent class, and this class and
+# the sibling class (ARK and/or URN) will inherit from this new parent class
+module Hyacinth::Ezid
+  class Doi
+    IDENTIFIER_STATUS = { public: 'public',
+                          reserved: 'reserved',
+                          unavailable: 'unavailable' }
+    attr_reader :identifier, :metadata
+    def initialize(doi_identifier, shadow_ark, status = IDENTIFIER_STATUS[:reserved], datacite_metadata = {})
+      @identifier = doi_identifier
+      @datacite_metadata = datacite_metadata
+
+      # following instance variables represent the Internal Metadata as
+      # specified by the EZID API, Version 2 (http://ezid.cdlib.org/doc/apidoc.html)
+      # In the API, the name is prefixed with an underscore. Underscore it not used
+      # in instance variable name due to special meaning attributed in ruby to names
+      # beginning with underscores
+      # BEGIN
+      @status = status
+      @shadowedby = shadow_ark
+      # END
+      # above instance variables represent the Internal Metadata as
+      # specified by the EZID API, Version 2 (http://ezid.cdlib.org/doc/apidoc.html)
+    end
+  end
+end

--- a/spec/fixtures/lib/hyacinth/ezid/datacite.xml
+++ b/spec/fixtures/lib/hyacinth/ezid/datacite.xml
@@ -1,0 +1,37 @@
+<resource xmlns="http://datacite.org/schema/kernel-3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://datacite.org/schema/kernel-3 http://schema.datacite.org/meta/kernel-3/metadata.xsd">
+  <identifier identifierType="DOI">10.1371/journal.pone.0119638</identifier>
+  <resourceType resourceTypeGeneral="still image"/>
+  <publisher>Columbia University</publisher>
+  <publicationYear>2015</publicationYear>
+  <date dateType="Created">2015-02-04</date>
+  <date dateType="Updated">2016-03-31</date>
+  <relatedIdentifiers>
+    <relatedIdentifier relatedIdentifierType="ISSN" relationType="isPartOf">1932-6203</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="ISBN" relationType="isPartOf">0670734608</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="isVariantFormOf">10.1371/journal.pone.0119638</relatedIdentifier>
+  </relatedIdentifiers>
+  <creators>
+    <creator>
+      <creatorName>Salinger, J. D.</creatorName>
+    </creator>
+    <creator>
+      <creatorName>Lincoln, Abraham</creatorName>
+    </creator>
+  </creators>
+  <titles>
+    <title>The Catcher in the Rye</title>
+  </titles>
+  <descriptions>
+    <description descriptionType="Abstract">This is an abstract; yes, a very nice abstract</description>
+  </descriptions>
+  <subjects>
+    <subject>Educational attainment</subject>
+    <subject>Parental influences</subject>
+    <subject>Mother and child--Psychological aspects</subject>
+  </subjects>
+  <contributors>
+    <contributor contributorType="Editor">
+      <contributorName>Lincoln, Abraham</contributorName>
+    </contributor>
+  </contributors>
+</resource>

--- a/spec/unit/hyacinth/ezid/datacite_metadata_builder_spec.rb
+++ b/spec/unit/hyacinth/ezid/datacite_metadata_builder_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+require 'equivalent-xml'
+
+describe Hyacinth::Ezid::DataciteMetadataBuilder do
+
+  let(:dod) {
+    data = JSON.parse( fixture('lib/hyacinth/ezid/ezid_item.json').read )
+    data['identifiers'] = ['item.' + SecureRandom.uuid] # random identifer to avoid collisions
+    data
+  }
+
+  before(:context) do
+
+    @expected_xml = Nokogiri::XML(fixture('lib/hyacinth/ezid/datacite.xml').read)
+
+  end
+
+  context "#datacite_xml:" do
+    
+    it "datacite_xml" do
+      metadata_retrieval = Hyacinth::Ezid::HyacinthMetadataRetrieval.new dod
+      metadata_builder = Hyacinth::Ezid::DataciteMetadataBuilder.new metadata_retrieval
+      actual_xml = metadata_builder.datacite_xml
+      expect(EquivalentXml.equivalent?(@expected_xml, actual_xml)).to eq(true)
+      
+    end
+
+  end
+
+end


### PR DESCRIPTION
This pull request contains the following:

- Code that will generate the datacite (http://schema.datacite.org) xml file used to push metadata to the EZID server.

- The Doi class, which encapsulates a few data members. Since there is no functionality besides attribute readers, there is no associated spec file for this class.

The branch represented by this pull request was successfully cap deploy'ed to the dev instance.