### PR TITLE
Do not include the resourceType in the datacite xml

### DIFF
--- a/lib/hyacinth/ezid/datacite_metadata_builder.rb
+++ b/lib/hyacinth/ezid/datacite_metadata_builder.rb
@@ -35,7 +35,9 @@ module Hyacinth::Ezid
           add_subjects xml
           add_contributors xml
           if @hyacinth_metadata_retrieval.type_of_resource.present?
-            xml.resourceType('resourceTypeGeneral' => @hyacinth_metadata_retrieval.type_of_resource)
+            # fcd1, 21Dec16: datacite has a controlled vocabulary for resource type, which does not
+            # match our values. This is an optional element in the schema, so for now skip it.
+            # xml.resourceType('resourceTypeGeneral' => @hyacinth_metadata_retrieval.type_of_resource)
           end
           if @hyacinth_metadata_retrieval.abstract.present?
             xml.descriptions { xml.description('descriptionType' => 'Abstract') { xml.text @hyacinth_metadata_retrieval.abstract } }

--- a/spec/fixtures/lib/hyacinth/ezid/datacite.xml
+++ b/spec/fixtures/lib/hyacinth/ezid/datacite.xml
@@ -1,6 +1,5 @@
 <resource xmlns="http://datacite.org/schema/kernel-3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://datacite.org/schema/kernel-3 http://schema.datacite.org/meta/kernel-3/metadata.xsd">
   <identifier identifierType="DOI">10.1371/journal.pone.0119638</identifier>
-  <resourceType resourceTypeGeneral="Image"/>
   <publisher>Columbia University</publisher>
   <publicationYear>1951</publicationYear>
   <dates>


### PR DESCRIPTION
The valid values for resourceType are specified in a datacite
vocabulary, which does not match the values in our vocabulary.
Since resourceType is not a required element, skip it.
In the future, we can try to come up with a mapping. However, this
mapping would have to be updated when we add new entries in our
vocabulary.