### PR TITLE
short circuit to false if checking basic editor permissions on a nil controlled vocabulary

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,6 +80,7 @@ class User < ActiveRecord::Base
   def can_manage_controlled_vocabulary_terms?(controlled_vocabulary)
     return true if admin?
     return true if can_manage_all_controlled_vocabularies?
+    return false if controlled_vocabulary.blank?
 
     projects_for_which_user_can_create_or_edit = ProjectPermission.where(user: self).where('project_permissions.can_create = ? OR project_permissions.can_update = ?', true, true).pluck(:project_id)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe User, :type => :model do
+  describe "#can_manage_controlled_vocabulary_terms?" do
+    context "nil parameter from index view" do
+      let(:controlled_vocabulary) { nil }
+      context "is admin" do
+        subject { described_class.new(is_admin: true) }
+        it { expect(subject.can_manage_controlled_vocabulary_terms?(controlled_vocabulary)).to be true }
+      end
+      context "can manage all" do
+        subject { described_class.new(can_manage_all_controlled_vocabularies: true) }
+        it { expect(subject.can_manage_controlled_vocabulary_terms?(controlled_vocabulary)).to be true }
+      end
+      context "is editor of project records" do
+        let(:editable_projects) { ['awe'] }
+
+        let(:relation) do
+          result = double(:relation)
+          allow(result).to receive(:where).and_return result
+          allow(result).to receive(:pluck).and_return editable_projects
+          result
+        end
+
+        before do
+          allow(ProjectPermission).to receive(:where).and_return(relation)
+        end
+
+        subject { described_class.new }
+        it { expect(subject.can_manage_controlled_vocabulary_terms?(controlled_vocabulary)).to be false }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is to clarify the otherwise confusing server error when metadata editors look at the controlled_vocabularies index view.