### PR TITLE
Lock redis gem at < 4 in order to maintain compatibility with resque …

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,6 +118,9 @@ gem 'addressable'
 # that doesn't work properly with the Blacklight gem dependency and raises:
 # ActiveSupport::Concern::MultipleIncludedBlocks: Cannot define multiple 'included' blocks for a Concern
 gem 'resque', '~> 1.26.0'
+# Need to lock to earlier version of redis gem because resque is calling
+# Redis.connect, and this method no longer exists in redis gem >= 4.0
+gem 'redis', '< 4' # Need to lock to earlier version of redis gem because resque is calling Redis.connect, and this method no longer exists in redis gem >= 4.0
 
 # For unique, opaque id generation
 gem 'noid', '>= 0.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -375,7 +375,7 @@ GEM
       rdf (~> 1.99)
     rdoc (4.2.0)
       json (~> 1.4)
-    redis (4.0.1)
+    redis (3.3.5)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
     ref (2.0.0)
@@ -570,6 +570,7 @@ DEPENDENCIES
   rake (~> 10.0)
   random-word
   rdf-rdfxml!
+  redis (< 4)
   resque (~> 1.26.0)
   retriable (~> 2.1)
   rspec-rails (~> 3.3)


### PR DESCRIPTION
…gem at 1.26