### PR TITLE
Unpublish on delete, HYACINTH-186

### DIFF
--- a/app/assets/javascripts/digital_objects_app/controllers/digital_objects_controller.js
+++ b/app/assets/javascripts/digital_objects_app/controllers/digital_objects_controller.js
@@ -150,7 +150,7 @@ Hyacinth.DigitalObjectsApp.DigitalObjectsController.prototype.edit = function() 
     //For deleting DigitalObjects
     $('.delete-digital-object-button').on('click', function(e){
       e.preventDefault();
-      var confirmResponse = confirm('Are you sure you want to delete this Digital Object?');
+      var confirmResponse = confirm('Are you sure you want to delete this Digital Object and unpublish it from all publish targets?');
       if (confirmResponse) {
         //After successful deletion, return to index page
         $.ajax({
@@ -288,15 +288,15 @@ Hyacinth.DigitalObjectsApp.DigitalObjectsController.prototype.publish_target_fie
     },
     cache: false
   }).done(function(data_for_editor){
-    
+
     var digitalObject = Hyacinth.DigitalObjectsApp.DigitalObject.Base.instantiateDigitalObjectFromData(data_for_editor['digital_object']);
-    
+
     $('#digital-object-dynamic-content').html(Hyacinth.DigitalObjectsApp.renderTemplate('digital_objects_app/digital_objects/publish_target_fields.ejs', {digitalObject: digitalObject}));
-    
+
     var publishTargetFieldsEditor = new Hyacinth.DigitalObjectsApp.DigitalObjectPublishTargetFieldsEditor('digital-object-publish-target-fields-editor', {
       digitalObject: digitalObject
     });
-    
+
     //Event cleanup
     that.dispose = function(){
       publishTargetFieldsEditor.dispose();
@@ -319,7 +319,7 @@ Hyacinth.DigitalObjectsApp.DigitalObjectsController.prototype.manage_children = 
     data: {},
     cache: false
   }).done(function(data_for_ordered_child_editor){
-    
+
     var digitalObject = Hyacinth.DigitalObjectsApp.DigitalObject.Base.instantiateDigitalObjectFromData(data_for_ordered_child_editor['digital_object']);
     var tooManyToShow = data_for_ordered_child_editor['too_many_to_show'];
     var orderedChildDigitalObjects = [];
@@ -368,7 +368,7 @@ Hyacinth.DigitalObjectsApp.DigitalObjectsController.prototype.upload_assets = fu
     var parentDigitalObject = Hyacinth.DigitalObjectsApp.DigitalObject.Base.instantiateDigitalObjectFromData(data_for_editor['digital_object']);
 
     $('#digital-object-dynamic-content').html(Hyacinth.DigitalObjectsApp.renderTemplate('digital_objects_app/digital_objects/upload_assets.ejs', {parentDigitalObject: parentDigitalObject}));
-    
+
     digital_object_data_for_new_asset = {
       project: {
         pid: parentDigitalObject.project['pid']
@@ -382,22 +382,22 @@ Hyacinth.DigitalObjectsApp.DigitalObjectsController.prototype.upload_assets = fu
         string_key: 'asset'
       }
     }
-    
+
     var fileBrowserWidget = new Hyacinth.DigitalObjectsApp.FileBrowserWidget();
     fileBrowserWidget.setTitle('Upload Directory Browser');
     fileBrowserWidget.setActionButtonLabel('Import');
     fileBrowserWidget.onActionButtonClick = function(){
-      
+
       Hyacinth.addAlert('Performing upload...', 'info');
-      
+
       digital_object_data_for_new_asset['import_file'] = {
         import_type : "upload_directory",
         import_path : fileBrowserWidget.getPathFieldValue()
       }
-      
+
       var filename = fileBrowserWidget.getPathFieldValue().replace(/^.*[\\\/]/, '');
       that.addUploadPlaceholder(filename);
-      
+
       $.ajax({
         url: '/digital_objects.json',
         type: 'POST',
@@ -410,17 +410,17 @@ Hyacinth.DigitalObjectsApp.DigitalObjectsController.prototype.upload_assets = fu
       }).fail(function(){
         alert(Hyacinth.unexpectedAjaxErrorMessage);
       });
-      
+
     };
     $('#filesystem_upload').append(fileBrowserWidget.$el);
-    
+
     var $uploadForm = $('.digital-object-asset-upload-form');
 
     digital_object_data_for_new_asset['import_file'] = {
       import_type : "post_data",
       import_path : fileBrowserWidget.getPathFieldValue()
     }
-    
+
     $uploadForm.fileupload({
         dataType: 'json',
         url: '/digital_objects.json',
@@ -468,12 +468,12 @@ Hyacinth.DigitalObjectsApp.DigitalObjectsController.prototype.upload_assets = fu
 };
 
 Hyacinth.DigitalObjectsApp.DigitalObjectsController.prototype.addUploadPlaceholder = function(filename) {
-  
+
   var $uploadedFilesTableBody = $('.uploaded-files-table tbody');
   if ($uploadedFilesTableBody.find('.placeholder').length > 0) {
     $uploadedFilesTableBody.find('.placeholder').remove();
   }
-  
+
   $(
     '<tr data-file-placeholder-for="' + _.escape(filename) + '">' +
       '<td>' + filename + '</td>' +
@@ -481,17 +481,17 @@ Hyacinth.DigitalObjectsApp.DigitalObjectsController.prototype.addUploadPlacehold
       '<td class="aligncenter">Pending...</td>' +
     '</tr>'
   ).appendTo($uploadedFilesTableBody);
-  
+
 };
 
 Hyacinth.DigitalObjectsApp.DigitalObjectsController.prototype.handleUploadResponse = function(response_data) {
 
   var $uploadedFilesTableBody = $('.uploaded-files-table tbody');
-  
+
   var name = response_data['uploaded_file_confirmation']['name'];
   var size = response_data['uploaded_file_confirmation']['size'];
   var errors = response_data['uploaded_file_confirmation']['errors'];
-    
+
   if (errors.length > 0) {
     Hyacinth.addAlert(errors[0], 'danger');
   } else {
@@ -507,7 +507,7 @@ Hyacinth.DigitalObjectsApp.DigitalObjectsController.prototype.handleUploadRespon
       fileSizeDisplayValue = parseInt(fileSize) + ' B';
     }
     var date = new Date();
-    
+
     $uploadedFilesTableBody.find('tr[data-file-placeholder-for="' + _.escape(name) + '"]').html(
       '<td>' + name + '</td>' +
       '<td class="aligncenter">' + fileSizeDisplayValue + '</td>' +
@@ -518,7 +518,7 @@ Hyacinth.DigitalObjectsApp.DigitalObjectsController.prototype.handleUploadRespon
 
     Hyacinth.addAlert('File upload complete: ' + name, 'info');
   }
-  
+
 }
 
 //Add Parent Action - Add a parent Digital Object to this Digital Object
@@ -561,7 +561,7 @@ Hyacinth.DigitalObjectsApp.DigitalObjectsController.prototype.manage_parents = f
       });
       return false;
     });
-    
+
     $('#remove-parent-form').on('submit', function(e){
       var parentsToRemove = [];
       $('#remove-parent-form').find('[name="parent_pid"]:checked').each(function(){
@@ -591,7 +591,7 @@ Hyacinth.DigitalObjectsApp.DigitalObjectsController.prototype.manage_parents = f
       });
       return false;
     });
-    
+
     //Event cleanup
     that.dispose = function(){
       $('#add-parent-form').off('submit');

--- a/app/models/concerns/digital_object/persistence.rb
+++ b/app/models/concerns/digital_object/persistence.rb
@@ -108,6 +108,9 @@ module DigitalObject::Persistence
       self.state = 'D'
 
       if valid? || force
+        # Unpublish items from active publish targets.
+        unpublish_all
+
         if purge
           # We're going to delete everything associated with this record
 

--- a/app/models/concerns/digital_object/publishing.rb
+++ b/app/models/concerns/digital_object/publishing.rb
@@ -6,7 +6,7 @@ module DigitalObject::Publishing
 
     # Save withg retry after Fedora timeouts / unreachable host
     Retriable.retriable DigitalObject::Base::RETRY_OPTIONS do
-      @fedora_object.save(update_index: false)
+      fedora_object.save(update_index: false)
     end
     allowed_publish_target_pids = allowed_publish_targets.map { |pub_target_data| pub_target_data['pid'] }
     inactive_publish_target_pids = allowed_publish_target_pids - publish_target_pids

--- a/app/models/concerns/digital_object/publishing.rb
+++ b/app/models/concerns/digital_object/publishing.rb
@@ -27,6 +27,11 @@ module DigitalObject::Publishing
     @errors.blank?
   end
 
+  def unpublish_all
+    @publish_target_pids = []
+    publish
+  end
+
   def execute_publish_action_for_target(publish_action, publish_target, do_ezid_update)
     return true if publish_target.publish_target_field('publish_url').blank? # Not all publish targets have publish URLs. Skip and return true if that's true for this pub target.
     success = false

--- a/spec/models/concerns/digital_object/publishing_spec.rb
+++ b/spec/models/concerns/digital_object/publishing_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+describe DigitalObject::Publishing do
+  let(:pubtarget_a) {
+    a = double(pid: 'pubtarget:a')
+    allow(a).to receive(:[]).with('pid').and_return('pubtarget:a')
+    allow(DigitalObject::Base).to receive(:find).with('pubtarget:a').and_return(a)
+    a
+  }
+  let(:pubtarget_b) {
+    b = double(pid: 'pubtarget:b')
+    allow(b).to receive(:[]).with('pid').and_return('pubtarget:b')
+    allow(DigitalObject::Base).to receive(:find).with('pubtarget:b').and_return(b)
+    b
+  }
+  let(:pubtarget_c) {
+    c = double(pid: 'pubtarget:c')
+    allow(c).to receive(:[]).with('pid').and_return('pubtarget:c')
+    allow(DigitalObject::Base).to receive(:find).with('pubtarget:c').and_return(c)
+    c
+  }
+
+  let(:digital_object) {
+    DigitalObject::Item.new.tap do |obj|
+      allow(obj).to receive(:before_publish).and_return(true)
+      allow(obj).to receive(:fedora_object).and_return(double(save: true))
+      allow(obj).to receive(:allowed_publish_targets).and_return([pubtarget_a, pubtarget_b, pubtarget_c])
+      allow(obj).to receive(:project).and_return(double(primary_publish_target_pid: pubtarget_a.pid))
+    end
+  }
+
+  describe '#publish' do
+    subject(:publish) { digital_object.publish }
+
+    it 'publishes to primary target' do
+      allow(digital_object).to receive(:publish_target_pids).and_return ['pubtarget:a']
+      expect(digital_object).to receive(:execute_publish_action_for_target).with(:unpublish, pubtarget_b, false).ordered
+      expect(digital_object).to receive(:execute_publish_action_for_target).with(:unpublish, pubtarget_c, false).ordered
+      expect(digital_object).to receive(:execute_publish_action_for_target).with(:publish, pubtarget_a, true).ordered
+      publish
+    end
+
+    it 'publishes to non-primary target' do
+      allow(digital_object).to receive(:publish_target_pids).and_return ['pubtarget:b']
+      expect(digital_object).to receive(:execute_publish_action_for_target).with(:unpublish, pubtarget_a, true).ordered
+      expect(digital_object).to receive(:execute_publish_action_for_target).with(:unpublish, pubtarget_c, false).ordered
+      expect(digital_object).to receive(:execute_publish_action_for_target).with(:publish, pubtarget_b, false).ordered
+      publish
+    end
+
+    it 'publishes to all targets' do
+      allow(digital_object).to receive(:publish_target_pids).and_return ['pubtarget:a', 'pubtarget:b', 'pubtarget:c']
+      expect(digital_object).to receive(:execute_publish_action_for_target).with(:publish, pubtarget_a, true).ordered
+      expect(digital_object).to receive(:execute_publish_action_for_target).with(:publish, pubtarget_b, false).ordered
+      expect(digital_object).to receive(:execute_publish_action_for_target).with(:publish, pubtarget_c, false).ordered
+      publish
+    end
+  end
+
+
+  describe '#unpublish_all' do
+    before do
+      digital_object.publish_target_pids = ['pubtarget:a', 'pubtarget:b', 'pubtarget:c']
+    end
+
+    subject(:unpublish_all) { digital_object.unpublish_all }
+
+    it 'unpublishes from all publishes targets' do
+      expect(digital_object).to receive(:execute_publish_action_for_target).with(:unpublish, pubtarget_a, true)
+      expect(digital_object).to receive(:execute_publish_action_for_target).with(:unpublish, pubtarget_b, false)
+      expect(digital_object).to receive(:execute_publish_action_for_target).with(:unpublish, pubtarget_c, false)
+      unpublish_all
+      expect(digital_object.publish_target_pids).to be_blank
+    end
+  end
+
+  describe '#execute_publish_action_for_target'
+end

--- a/spec/models/digital_object/file_system_spec.rb
+++ b/spec/models/digital_object/file_system_spec.rb
@@ -36,10 +36,10 @@ describe DigitalObject::FileSystem, :type => :model do
       subject
     end
 
-    it do
+    it "does not access any fedora datastreams when publishing" do
       pending("Pending: further implementation required")
-      allow(subject).to receive(:publish_descriptions) # .and_return(subject)
-      expect(subject).not_to receive(:publish_structures)
+
+      expect(subject.fedora_object).not_to receive(:datastreams)
       subject.publish
     end
   end


### PR DESCRIPTION
Unpublishing from all publish targets when an item is deleted.

I am not sure the tests I added are helpful, but it helped me understand the logic better. I have a feeling that I may be missing something else that needs to happen as part of this process. @elohanlon, let me know if you can think of anything. Should we add something to the delete dialog that says something along the lines of "Deleting this object unpublishes it from all publish targets"?