### PR TITLE
Adding first_published_at. HYACINTH-196

### DIFF
--- a/app/assets/javascripts/digital_objects_app/models/digital_object/base.js
+++ b/app/assets/javascripts/digital_objects_app/models/digital_object/base.js
@@ -117,6 +117,11 @@ Hyacinth.DigitalObjectsApp.DigitalObject.Base.prototype.getModifiedBy = function
 Hyacinth.DigitalObjectsApp.DigitalObject.Base.prototype.getModified = function(){
   return new Date(this.modified);
 };
+
+Hyacinth.DigitalObjectsApp.DigitalObject.Base.prototype.getFirstPublished = function(){
+  return (this.first_published ? new Date(this.first_published) : null);
+};
+
 Hyacinth.DigitalObjectsApp.DigitalObject.Base.prototype.getDoi = function(){
   return this.doi || null;
 };

--- a/app/assets/templates/digital_objects_app/widgets/digital_object_editor/_header.ejs
+++ b/app/assets/templates/digital_objects_app/widgets/digital_object_editor/_header.ejs
@@ -96,7 +96,7 @@
               <%= digitalObject.digital_object_type['display_label'] %> History:
             </label>
             <div class="col-sm-9">
-              <a href="#history" data-toggle="collapse">Creation / Modification Info</a>
+              <a href="#history" data-toggle="collapse">Record Info</a>
             </div>
           </div>
 
@@ -134,6 +134,15 @@
               </label>
               <div class="col-sm-9">
                 <%= digitalObject.getModified() || '- Assigned After Save -' %>
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label class="col-sm-3">
+                First Published At:
+              </label>
+              <div class="col-sm-9">
+                <%= digitalObject.getFirstPublished() || '- Assigned After Publish to Primary Publish Target -' %>
               </div>
             </div>
           </div>

--- a/app/jobs/export_search_results_to_csv_job.rb
+++ b/app/jobs/export_search_results_to_csv_job.rb
@@ -3,7 +3,7 @@ class ExportSearchResultsToCsvJob
 
   SUPPRESSED_ON_EXPORT = ['_dc_type', '_state', '_title', '_created', '_modified', '_created_by', '_modified_by', '_project.uri', '_project.short_label']
   INTERNAL_FIELD_REGEXES_ALLOWED_ON_IMPORT = [
-    '_pid', '_doi', '_merge_dynamic_fields', '_publish', '_digital_object_type.string_key', '_import_file.import_type', '_import_file.import_path', '_import_file.original_file_path', '_restrictions.restricted_size_image', '_restrictions.restricted_onsite',
+    '_pid', '_doi', '_merge_dynamic_fields', '_publish', '_first_published', '_digital_object_type.string_key', '_import_file.import_type', '_import_file.import_path', '_import_file.original_file_path', '_restrictions.restricted_size_image', '_restrictions.restricted_onsite',
     /^_publish_target_data\.(string_key|publish_url|api_key|representative_image_pid|short_title|short_description|full_description|restricted|slug|site_url)$/,
     /^_parent_digital_objects-\d+\.(identifier|pid)$/, /^_identifiers-\d+$/, /^_project\.(string_key|pid)$/,
     /^_publish_targets-\d+\.(string_key|pid)$/, /^_parent_digital_objects-\d+\.(identifier|pid)$/

--- a/app/models/concerns/digital_object/digital_object_record.rb
+++ b/app/models/concerns/digital_object/digital_object_record.rb
@@ -5,9 +5,10 @@ module DigitalObject::DigitalObjectRecord
   # DB object data loading methods #
   ##################################
 
-  def load_created_and_updated_data_from_db_record!
+  def load_data_from_db_record!
     @created_by = @db_record.created_by
     @updated_by = @db_record.updated_by
+    @first_published_at = @db_record.first_published_at
   end
 
   ##################################
@@ -22,5 +23,22 @@ module DigitalObject::DigitalObjectRecord
 
     @db_record.updated_by = @updated_by
     @db_record.updated_at = Time.now # Always setting this manually just in case there aren't any other changes to @db_record (becase otherwise the record's updated_at time wouldn't change automatically)
+  end
+
+  def set_first_published_at
+    # Save _first_published_at date, if we are going to attempt to publish to
+    # primary publish target. Otherwise, convert date if it is a String
+    if @first_published_at.blank? && publishing_to_primary_publish_target?
+      @first_published_at = Time.current
+    elsif @first_published_at.is_a?(String)
+      begin
+        @first_published_at = Time.iso8601(@first_published_at)
+      rescue ArgumentError => e
+        @errors.add(:first_published_at, 'first_published_at date invalid. Date must be in valid ISO8601 format.')
+      end
+    end
+
+    # Setting string to field will result in saving nil.
+    @db_record.first_published_at = @first_published_at if @first_published_at.is_a?(Time)
   end
 end

--- a/app/models/concerns/digital_object/persistence.rb
+++ b/app/models/concerns/digital_object/persistence.rb
@@ -57,7 +57,7 @@ module DigitalObject::Persistence
 
       run_post_validation_pre_save_logic
 
-      set_fedora_object_properties
+      set_data_to_sources
 
       @db_record.save! # Save timestamps + updates to modifed_by, etc.
 

--- a/app/models/concerns/digital_object/publishing.rb
+++ b/app/models/concerns/digital_object/publishing.rb
@@ -50,4 +50,8 @@ module DigitalObject::Publishing
     end
     success
   end
+
+  def publishing_to_primary_publish_target?
+    @publish_after_save && publish_target_pids.include?(project.primary_publish_target_pid)
+  end
 end

--- a/app/models/concerns/digital_object/serialization.rb
+++ b/app/models/concerns/digital_object/serialization.rb
@@ -9,8 +9,9 @@ module DigitalObject::Serialization
   def as_json(_options = {})
     {
       pid: pid,
-      created: @db_record.created_at.present? ? @db_record.created_at.iso8601 : nil,
-      modified: @db_record.updated_at.present? ? @db_record.updated_at.iso8601 : nil,
+      created: format_date(@db_record.created_at),
+      modified: format_date(@db_record.updated_at),
+      first_published: format_date(@db_record.first_published_at),
       created_by: (@db_record.created_by.present? ? @db_record.created_by.full_name : nil),
       modified_by: (@db_record.updated_by.present? ? @db_record.updated_by.full_name : nil),
       identifiers: identifiers,
@@ -31,4 +32,9 @@ module DigitalObject::Serialization
   def as_confirmation_json
     { pid: pid }
   end
+
+  private
+    def format_date(date)
+      date.present? ? date.iso8601 : nil
+    end
 end

--- a/app/models/digital_object/asset.rb
+++ b/app/models/digital_object/asset.rb
@@ -250,7 +250,7 @@ class DigitalObject::Asset < DigitalObject::Base
     self.restricted_onsite = fedora_object.relationships(:restriction).include?(ONSITE_RESTRICTION_LITERAL_VALUE)
   end
 
-  def set_fedora_object_properties
+  def set_data_to_sources
     super
 
     if restricted_size_image

--- a/app/models/digital_object/base.rb
+++ b/app/models/digital_object/base.rb
@@ -20,7 +20,7 @@ class DigitalObject::Base
   # For ActiveModel::Dirty
   define_attribute_methods :parent_digital_object_pids, :obsolete_parent_digital_object_pids, :ordered_child_digital_object_pids
 
-  attr_accessor :project, :publish_target_pids, :identifiers, :created_by, :updated_by, :state, :dc_type, :ordered_child_digital_object_pids, :publish_after_save, :mint_reserved_doi_before_save, :doi
+  attr_accessor :project, :publish_target_pids, :identifiers, :created_by, :updated_by, :first_published_at, :state, :dc_type, :ordered_child_digital_object_pids, :publish_after_save, :mint_reserved_doi_before_save, :doi
   attr_reader :errors, :fedora_object, :parent_digital_object_pids
 
   delegate :created_at, :new_record?, :updated_at, to: :@db_record
@@ -65,7 +65,7 @@ class DigitalObject::Base
   end
 
   def load_data_from_sources
-    load_created_and_updated_data_from_db_record!
+    load_data_from_db_record!
     load_parent_digital_object_pid_relationships_from_fedora_object!
     load_state_from_fedora_object!
     load_dc_type_from_fedora_object!
@@ -77,6 +77,7 @@ class DigitalObject::Base
 
   def set_fedora_object_properties
     set_created_and_updated_data_from_db_record
+    set_first_published_at
     set_fedora_hyacinth_ds_data
     set_fedora_project_and_publisher_relationships
     set_fedora_object_state
@@ -116,6 +117,9 @@ class DigitalObject::Base
 
     # Allow setting of doi if doi hasn't already been set
     @doi = digital_object_data['doi'] if @doi.blank? && digital_object_data['doi'].present?
+
+    # Allow setting of first_published_at if the field isn't blank
+    @first_published_at = digital_object_data['first_published'] if digital_object_data['first_published'].present?
 
     # Project (only one) -- Only allow setting this if this DigitalObject is a new record
     self.project = project_from_data(digital_object_data) if self.new_record?

--- a/app/models/digital_object/base.rb
+++ b/app/models/digital_object/base.rb
@@ -75,7 +75,7 @@ class DigitalObject::Base
     load_fedora_hyacinth_ds_data_from_fedora_object!
   end
 
-  def set_fedora_object_properties
+  def set_data_to_sources
     set_created_and_updated_data_from_db_record
     set_first_published_at
     set_fedora_hyacinth_ds_data

--- a/db/migrate/20180122214510_add_first_published_at_to_digital_object_records.rb
+++ b/db/migrate/20180122214510_add_first_published_at_to_digital_object_records.rb
@@ -1,0 +1,5 @@
+class AddFirstPublishedAtToDigitalObjectRecords < ActiveRecord::Migration
+  def change
+    add_column :digital_object_records, :first_published_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171110194020) do
+ActiveRecord::Schema.define(version: 20180122214510) do
 
   create_table "controlled_vocabularies", force: :cascade do |t|
     t.string   "string_key"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 20171110194020) do
     t.integer  "updated_by_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.datetime "first_published_at"
   end
 
   add_index "digital_object_records", ["pid"], name: "index_digital_object_records_on_pid", unique: true

--- a/spec/models/digital_object/base_spec.rb
+++ b/spec/models/digital_object/base_spec.rb
@@ -358,7 +358,6 @@ RSpec.describe DigitalObject::Base, :type => :model do
     end
 
     it "can create a new DigitalObject for an existing Fedora object that isn't being tracked by Hyacinth, and preserves identifiers, parents and publish targets from that Fedora object" do
-
         existing_parent_object_pid = 'test:existing_parent_object'
         existing_parent_object = Collection.new(:pid => existing_parent_object_pid)
         existing_parent_object.save
@@ -418,6 +417,12 @@ RSpec.describe DigitalObject::Base, :type => :model do
       it "calls publish method" do
         expect(item).to receive(:publish)
         item.save
+      end
+
+      it "sets first_published_at date" do
+        item.save
+        expect(item.first_published_at).to be_within(10.seconds).of(Time.current)
+        expect(item.instance_variable_get(:@db_record).first_published_at).to be_within(10.seconds).of(Time.current)
       end
     end
   end


### PR DESCRIPTION
- Added first_published_at field to dynamic object record
- Added to serialization methods
- Displaying field in GUI
- Field can be set via CSV import
- first_published_at date is set when object is first published to its primary target

MISSING: Adding first_published_at to MODS serialization. We'll need to do more research on this, but should move forward with this code, so we can start populating the field.