### PR TITLE
HYACINTH-310: Remove deprecated shadow ARK from DOI processing

### DIFF
--- a/lib/hyacinth/ezid/api_session.rb
+++ b/lib/hyacinth/ezid/api_session.rb
@@ -16,8 +16,6 @@ module Hyacinth::Ezid
     attr_accessor :naa, :username, :password
     attr_reader :scheme, :last_response_from_server, :timed_out
 
-    SCHEMES = { ark: 'ark:/', doi: 'doi:' }
-
     IDENTIFIER_STATUS = { public: 'public',
                           reserved: 'reserved',
                           unavailable: 'unavailable' }
@@ -76,7 +74,6 @@ module Hyacinth::Ezid
                                              "datacite metadata: #{metadata.inspect}") unless @last_response_from_server.success?
         # BEGIN_CHUNK
         Hyacinth::Ezid::Doi.new(@last_response_from_server.doi,
-                                @last_response_from_server.ark,
                                 identifier_status) if @last_response_from_server.success?
         # END_CHUNK
       rescue Net::ReadTimeout, SocketError

--- a/lib/hyacinth/ezid/doi.rb
+++ b/lib/hyacinth/ezid/doi.rb
@@ -8,7 +8,7 @@ module Hyacinth::Ezid
                           reserved: 'reserved',
                           unavailable: 'unavailable' }
     attr_reader :identifier, :metadata
-    def initialize(doi_identifier, shadow_ark, status = IDENTIFIER_STATUS[:reserved], datacite_metadata = {})
+    def initialize(doi_identifier, status = IDENTIFIER_STATUS[:reserved], datacite_metadata = {})
       @identifier = doi_identifier
       @datacite_metadata = datacite_metadata
 
@@ -19,7 +19,6 @@ module Hyacinth::Ezid
       # beginning with underscores
       # BEGIN
       @status = status
-      @shadowedby = shadow_ark
       # END
       # above instance variables represent the Internal Metadata as
       # specified by the EZID API, Version 2 (http://ezid.cdlib.org/doc/apidoc.html)

--- a/lib/hyacinth/ezid/server_response.rb
+++ b/lib/hyacinth/ezid/server_response.rb
@@ -20,11 +20,6 @@ module Hyacinth::Ezid
       match[0]
     end
 
-    def ark
-      match = @response.body.match(/ark\S+/)
-      match[0]
-    end
-
     def http_status_code
       @response.code
     end

--- a/spec/unit/hyacinth/ezid/server_response_spec.rb
+++ b/spec/unit/hyacinth/ezid/server_response_spec.rb
@@ -3,19 +3,15 @@ require 'rails_helper'
 describe Hyacinth::Ezid::ServerResponse do
 
   let(:expected_parsed_body) {
-{"success"=>" doi:10.5072/FK27P90J1D", "_updated"=>" 1477929976", "_target"=>" http://ezid.cdlib.org/id/doi:10.5072/FK27P90J1D", "_profile"=>" datacite", "_ownergroup"=>" apitest", "_owner"=>" apitest", "_shadowedby"=>" ark:/b5072/fk27p90j1d", "_export"=>" yes", "_created"=>" 1477929976", "_status"=>" reserved", "_datacenter"=>" CDL.CDL"}
+{"success"=>" doi:10.5072/FK27P90J1D", "_updated"=>" 1477929976", "_target"=>" http://ezid.cdlib.org/id/doi:10.5072/FK27P90J1D", "_profile"=>" datacite", "_ownergroup"=>" apitest", "_owner"=>" apitest", "_export"=>" yes", "_created"=>" 1477929976", "_status"=>" reserved", "_datacenter"=>" CDL.CDL"}
   }
 
   let(:sample_response_body) {
-        "success: doi:10.5072/FK27P90J1D\n_updated: 1477929976\n_target: http://ezid.cdlib.org/id/doi:10.5072/FK27P90J1D\n_profile: datacite\n_ownergroup: apitest\n_owner: apitest\n_shadowedby: ark:/b5072/fk27p90j1d\n_export: yes\n_created: 1477929976\n_status: reserved\n_datacenter: CDL.CDL\n"
+        "success: doi:10.5072/FK27P90J1D\n_updated: 1477929976\n_target: http://ezid.cdlib.org/id/doi:10.5072/FK27P90J1D\n_profile: datacite\n_ownergroup: apitest\n_owner: apitest\n_export: yes\n_created: 1477929976\n_status: reserved\n_datacenter: CDL.CDL\n"
   }
 
   let(:expected_doi) {
     'doi:10.5072/FK27P90J1D'
-  }
-
-  let(:expected_ark) {
-    'ark:/b5072/fk27p90j1d'
   }
 
   context "#parse_body" do
@@ -35,16 +31,6 @@ describe Hyacinth::Ezid::ServerResponse do
       ezid_server_response = Hyacinth::Ezid::ServerResponse.new dbl
       actual_doi = ezid_server_response.doi
       expect(actual_doi).to eq(expected_doi)
-    end
-  end
-
-  context "#ark" do
-    it "ark" do
-      dbl = double(Net::HTTPOK)
-      allow(dbl).to receive(:body) { sample_response_body }
-      ezid_server_response = Hyacinth::Ezid::ServerResponse.new dbl
-      actual_ark = ezid_server_response.ark
-      expect(actual_ark).to eq(expected_ark)
     end
   end
 end


### PR DESCRIPTION
Besides being deprecated, we never used the shadow ARK, plus the DataCite EZ API does not return one when minting a DOI.