### PR TITLE
Publish Targets API

### DIFF
--- a/app/controllers/api/v1/projects/publish_targets_controller.rb
+++ b/app/controllers/api/v1/projects/publish_targets_controller.rb
@@ -1,0 +1,57 @@
+module Api
+  module V1
+    module Projects
+      class PublishTargetsController < ApplicationApiController
+        load_resource :project, find_by: :string_key, id_param: :project_string_key
+        load_resource :publish_target, find_by: :string_key, id_param: :string_key, through: :project
+
+        # GET /projects/:string_key/publish_targets
+        def index
+          render json: { publish_targets: @project.publish_targets }, status: 200
+        end
+
+        # GET /projects/:string_key/publish_targets/:string_key
+        def show
+          render json: { publish_target: @publish_target }, status: 200
+        end
+
+        # POST /projects/:string_key/publish_targets
+        def create
+          if @publish_target.save
+            render json: { publish_target: @publish_target }, status: :created
+          else
+            render json: errors(@publish_target.errors.full_messages), status: :unprocessable_entity
+          end
+        end
+
+        # PATCH /projects/:string_key/publish_targets/:string_key
+        def update
+          if @publish_target.update(update_params)
+            render json: { publish_target: @publish_target }, status: :ok
+          else
+            render json: errors(@publish_target.errors.full_messages), status: :unprocessable_entity
+          end
+        end
+
+        # DELETE /projects/:string_key/publish_targets/:string_key
+        def destroy
+          if @publish_target.destroy
+            head :no_content
+          else
+            render json: errors('Deleting was unsuccessful.'), status: :unprocessable_entity
+          end
+        end
+
+        private
+
+          def create_params
+            params.require(:publish_target).permit(:string_key, :display_label, :publish_url, :api_key)
+          end
+
+          def update_params
+            params.require(:publish_target).permit(:display_label, :publish_url, :api_key)
+          end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/projects/publish_targets_controller.rb
+++ b/app/controllers/api/v1/projects/publish_targets_controller.rb
@@ -7,12 +7,12 @@ module Api
 
         # GET /projects/:string_key/publish_targets
         def index
-          render json: { publish_targets: @project.publish_targets }, status: 200
+          render json: { publish_targets: @project.publish_targets }, status: :ok
         end
 
         # GET /projects/:string_key/publish_targets/:string_key
         def show
-          render json: { publish_target: @publish_target }, status: 200
+          render json: { publish_target: @publish_target }, status: :ok
         end
 
         # POST /projects/:string_key/publish_targets

--- a/app/models/publish_target.rb
+++ b/app/models/publish_target.rb
@@ -1,3 +1,16 @@
 class PublishTarget < ApplicationRecord
   belongs_to :project
+
+  validates :string_key, presence: true, uniqueness: true, string_key: true
+  validates :display_label, :publish_url, :api_key, presence: true
+
+  def as_json(_options = {})
+    {
+      project: project.string_key,
+      string_key: string_key,
+      display_label: display_label,
+      publish_url: publish_url,
+      api_key: api_key
+    }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,9 @@ Rails.application.routes.draw do
         resources :terms, param: :uri, except: [:new, :edit], module: 'vocabularies'
       end
 
-      resources :projects, param: :string_key, except: [:new, :edit]
+      resources :projects, param: :string_key, except: [:new, :edit] do
+        resources :publish_targets, param: :string_key, except: [:new, :edit], module: 'projects'
+      end
     end
   end
 end

--- a/db/migrate/20190319163208_require_columns_to_publish_targets.rb
+++ b/db/migrate/20190319163208_require_columns_to_publish_targets.rb
@@ -1,0 +1,8 @@
+class RequireColumnsToPublishTargets < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :publish_targets, :string_key, false
+    change_column_null :publish_targets, :display_label, false
+    change_column_null :publish_targets, :publish_url, false
+    change_column_null :publish_targets, :api_key, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_18_141027) do
+ActiveRecord::Schema.define(version: 2019_03_19_163208) do
 
   create_table "database_entry_locks", force: :cascade do |t|
     t.string "lock_key", null: false
@@ -63,10 +63,10 @@ ActiveRecord::Schema.define(version: 2019_03_18_141027) do
 
   create_table "publish_targets", force: :cascade do |t|
     t.integer "project_id"
-    t.string "string_key"
-    t.string "display_label"
-    t.text "publish_url"
-    t.string "api_key"
+    t.string "string_key", null: false
+    t.string "display_label", null: false
+    t.text "publish_url", null: false
+    t.string "api_key", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["project_id"], name: "index_publish_targets_on_project_id"

--- a/spec/factories/publish_targets.rb
+++ b/spec/factories/publish_targets.rb
@@ -1,5 +1,11 @@
 FactoryBot.define do
   factory :publish_target do
+    string_key { 'great_project_website' }
+    display_label { 'Great Project Website' }
+    publish_url { 'https://www.example.com/publish' }
+    api_key { 'bestapikey' }
+    association :project, factory: :project, strategy: :create
+
     factory :legend_of_lincoln_publish_target do
       project { nil } # project should be passed in when factory build or create or called, otherwise this object won't validate
       string_key { 'legend_of_lincoln_website' }

--- a/spec/models/publish_target_spec.rb
+++ b/spec/models/publish_target_spec.rb
@@ -1,5 +1,66 @@
 require 'rails_helper'
 
 RSpec.describe PublishTarget, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#new' do
+    context 'when all parameters correct' do
+      subject { FactoryBot.create(:publish_target) }
+
+      its(:string_key) { is_expected.to eql 'great_project_website' }
+      its(:display_label) { is_expected.to eql 'Great Project Website' }
+      its(:publish_url) { is_expected.to eql 'https://www.example.com/publish' }
+      its(:api_key) { is_expected.to eql 'bestapikey' }
+    end
+
+    context 'when string_key missing' do
+      subject { FactoryBot.build(:publish_target, string_key: nil) }
+
+      it 'does not save object' do
+        expect(subject.save).to be false
+      end
+
+      it 'returns correct error' do
+        subject.save
+        expect(subject.errors.full_messages).to include 'String key can\'t be blank'
+      end
+    end
+
+    context 'when display_label missing' do
+      subject { FactoryBot.build(:publish_target, display_label: nil) }
+
+      it 'does not save object' do
+        expect(subject.save).to be false
+      end
+
+      it 'returns correct error' do
+        subject.save
+        expect(subject.errors.full_messages).to include 'Display label can\'t be blank'
+      end
+    end
+
+    context 'when publish_url missing' do
+      subject { FactoryBot.build(:publish_target, publish_url: nil) }
+
+      it 'does not save object' do
+        expect(subject.save).to be false
+      end
+
+      it 'returns correct error' do
+        subject.save
+        expect(subject.errors.full_messages).to include 'Publish url can\'t be blank'
+      end
+    end
+
+    context 'when api_key missing' do
+      subject { FactoryBot.build(:publish_target, api_key: nil) }
+
+      it 'does not save object' do
+        expect(subject.save).to be false
+      end
+
+      it 'returns correct error' do
+        subject.save
+        expect(subject.errors.full_messages).to include 'Api key can\'t be blank'
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/projects/publish_targets_spec.rb
+++ b/spec/requests/api/v1/projects/publish_targets_spec.rb
@@ -1,0 +1,206 @@
+require 'rails_helper'
+
+RSpec.describe 'Publish Target requests' do
+  let(:project) { FactoryBot.create(:project) }
+
+  describe 'GET /api/v1/projects/:string_key/publish_targets' do
+    describe 'when there are multiple results' do
+      before do
+        FactoryBot.create(:publish_target, project: project)
+        FactoryBot.create(:publish_target, project: project, string_key: 'second_publish_target')
+        get "/api/v1/projects/#{project.string_key}/publish_targets"
+      end
+
+      it 'returns all projects' do
+        expect(response.body).to be_json_eql(%(
+          {
+            "publish_targets": [
+              {
+                "api_key": "bestapikey",
+                "display_label": "Great Project Website",
+                "project": "great_project",
+                "publish_url": "https://www.example.com/publish",
+                "string_key": "great_project_website"
+              },
+              {
+                "api_key": "bestapikey",
+                "display_label": "Great Project Website",
+                "project": "great_project",
+                "publish_url": "https://www.example.com/publish",
+                "string_key": "second_publish_target"
+              }
+            ]
+          }
+        ))
+      end
+
+      it 'returns 200' do
+        expect(response.status).to be 200
+      end
+    end
+  end
+
+  describe 'GET /api/v1/projects/:string_key/publish_targets/:string_key' do
+    context 'when string_key is valid' do
+      before do
+        publish_target = FactoryBot.create(:publish_target, project: project)
+        get "/api/v1/projects/#{project.string_key}/publish_targets/#{publish_target.string_key}"
+      end
+
+      it 'returns 200' do
+        expect(response.status).to be 200
+      end
+
+      it 'returns correct response' do
+        expect(response.body).to be_json_eql(%({
+          "publish_target": {
+            "api_key": "bestapikey",
+            "display_label": "Great Project Website",
+            "project": "great_project",
+            "publish_url": "https://www.example.com/publish",
+            "string_key": "great_project_website"
+          }
+        }))
+      end
+    end
+
+    context 'when string_key is invalid' do
+      before { get "/api/v1/projects/#{project.string_key}/publish_targets/not_valid" }
+
+      it 'returns 404' do
+        expect(response.status).to be 404
+      end
+
+      it 'returns correct response' do
+        expect(response.body).to be_json_eql(%(
+          { "errors": [{ "title": "Not Found" }] }
+        ))
+      end
+    end
+  end
+
+  describe 'POST /api/v1/projects/:string_key/publish_targets' do
+    context 'when creating a new publish target' do
+      before do
+        post "/api/v1/projects/#{project.string_key}/publish_targets", params: {
+          publish_target: {
+            display_label: 'Best Project Website',
+            string_key: 'best_project_website',
+            publish_url: 'https://bestproject/publish',
+            api_key: 'bestprojectapikey'
+          }
+        }
+      end
+
+      it 'returns 201' do
+        expect(response.status).to be 201
+      end
+
+      it 'returns correct response' do
+        expect(response.body).to be_json_eql(%({
+          "publish_target": {
+            "project": "#{project.string_key}",
+            "display_label": "Best Project Website",
+            "string_key": "best_project_website",
+            "publish_url": "https://bestproject/publish",
+            "api_key": "bestprojectapikey"
+          }
+        }))
+      end
+    end
+
+    context 'when create request is missing string_key' do
+      before do
+        post "/api/v1/projects/#{project.string_key}/publish_targets", params: {
+          publish_target: {
+            display_label: 'Best Project Website',
+            publish_url: 'https://bestproject/publish',
+            api_key: 'bestprojectapikey'
+          }
+        }
+      end
+
+      it 'returns 422' do
+        expect(response.status).to be 422
+      end
+
+      it 'returns error' do
+        expect(response.body).to be_json_eql(%({
+          "errors": [
+            { "title": "String key can't be blank" }
+          ]
+        }))
+      end
+    end
+  end
+
+  describe 'PATCH /api/v1/projects/:string_key/publish_targets/:string_key' do
+    let(:publish_target) { FactoryBot.create(:publish_target, project: project) }
+
+    context 'when updating record' do
+      before do
+        patch "/api/v1/projects/#{project.string_key}/publish_targets/#{publish_target.string_key}", params: {
+          publish_target: { display_label: 'Bestest Project', publish_url: 'https://best_project.com/publish' }
+        }
+      end
+
+      it 'returns 200' do
+        expect(response.status).to be 200
+      end
+
+      it 'correctly updates record' do
+        publish_target.reload
+        expect(publish_target.display_label).to eql 'Bestest Project'
+        expect(publish_target.publish_url).to eql 'https://best_project.com/publish'
+      end
+    end
+
+    context 'when string_key given' do
+      before do
+        patch "/api/v1/projects/#{project.string_key}/publish_targets/#{publish_target.string_key}", params: {
+          publish_target: { string_key: 'new_string_key' }
+        }
+      end
+
+      it 'does not update string_key' do
+        publish_target.reload
+        expect(publish_target.string_key).to eql 'great_project_website'
+      end
+    end
+  end
+
+  describe 'DELETE /api/v1/projects/:string_key/publish_targets/:string_key' do
+    let(:string_key) { 'great_project_publish_target' }
+
+    context 'when deleting a project that exists' do
+      before do
+        FactoryBot.create(:publish_target, project: project, string_key: string_key)
+        delete "/api/v1/projects/#{project.string_key}/publish_targets/#{string_key}"
+      end
+
+      it 'returns 204' do
+        expect(response.status).to be 204
+      end
+
+      it 'deletes record from database' do
+        expect(PublishTarget.find_by(project: project, string_key: string_key)).to be nil
+      end
+    end
+
+    context 'when deleting a project that dooes not exist' do
+      before do
+        delete "/api/v1/projects/#{project.string_key}/publish_targets/not-valid"
+      end
+
+      it 'returns errors' do
+        expect(response.body).to be_json_eql(%(
+          { "errors": [ { "title": "Not Found" } ] }
+        ))
+      end
+
+      it 'returns 404' do
+        expect(response.status).to be 404
+      end
+    end
+  end
+end


### PR DESCRIPTION
Basic endpoint to CRUD a publish target. 

Note:
- This does not include permissions.
- This also does not include priority of publish target