### PR TITLE
No longer using :index, :show, :edit and :new to define permissions

### DIFF
--- a/app/javascript/hyacinth_ui_v1/components/controlled_vocabularies/ControlledVocabularies.js
+++ b/app/javascript/hyacinth_ui_v1/components/controlled_vocabularies/ControlledVocabularies.js
@@ -18,7 +18,7 @@ export default class ControlledVocabularies extends React.PureComponent {
           exact
           path="/controlled_vocabularies"
           component={ControlledVocabularyIndex}
-          requiredAbility={{ action: 'index', subject: 'Vocabulary' }}
+          requiredAbility={{ action: 'read', subject: 'Vocabulary' }}
         />
 
         <ProtectedRoute

--- a/app/javascript/hyacinth_ui_v1/components/controlled_vocabularies/terms/Terms.js
+++ b/app/javascript/hyacinth_ui_v1/components/controlled_vocabularies/terms/Terms.js
@@ -18,7 +18,7 @@ export default class Terms extends React.PureComponent {
           exact
           path="/controlled_vocabularies/:stringKey/terms"
           component={TermIndex}
-          requiredAbility={{ action: 'index', subject: 'ControlledVocabulary' }}
+          requiredAbility={{ action: 'read', subject: 'ControlledVocabulary' }}
         /> */}
 
         <ProtectedRoute

--- a/app/javascript/hyacinth_ui_v1/components/dynamic_fields/DynamicFields.js
+++ b/app/javascript/hyacinth_ui_v1/components/dynamic_fields/DynamicFields.js
@@ -15,7 +15,7 @@ export default class DynamicFields extends React.PureComponent {
           exact
           path="/dynamic_fields"
           component={DynamicFieldIndex}
-          requiredAbility={{ action: 'index', subject: 'DynamicField' }}
+          requiredAbility={{ action: 'read', subject: 'DynamicField' }}
         />
 
         <ProtectedRoute

--- a/app/javascript/hyacinth_ui_v1/components/field_export_profiles/FieldExportProfiles.js
+++ b/app/javascript/hyacinth_ui_v1/components/field_export_profiles/FieldExportProfiles.js
@@ -15,7 +15,7 @@ export default class FieldExportProfiles extends React.PureComponent {
           exact
           path="/field_export_profiles"
           component={FieldExportProfileIndex}
-          requiredAbility={{ action: 'index', subject: 'FieldExportProfile' }}
+          requiredAbility={{ action: 'read', subject: 'FieldExportProfile' }}
         />
         <ProtectedRoute
           exact

--- a/app/javascript/hyacinth_ui_v1/components/projects/core_data/CoreDataShow.js
+++ b/app/javascript/hyacinth_ui_v1/components/projects/core_data/CoreDataShow.js
@@ -21,7 +21,7 @@ function CoreDataShow() {
     <ProjectInterface project={data.project}>
       <TabHeading>
         Core Data
-        <Can I="edit" of={{ subjectType: 'Project', stringKey: data.project.stringKey }}>
+        <Can I="update" of={{ subjectType: 'Project', stringKey: data.project.stringKey }}>
           <EditButton
             className="float-right"
             size="lg"

--- a/app/javascript/hyacinth_ui_v1/components/users/UserEdit.js
+++ b/app/javascript/hyacinth_ui_v1/components/users/UserEdit.js
@@ -86,7 +86,7 @@ function UserEdit() {
 
   let rightHandLinks = [];
 
-  if (ability.can('index', 'Users')) {
+  if (ability.can('read', 'Users')) {
     rightHandLinks = [{ link: '/users', label: 'Back to All Users' }];
   }
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -7,7 +7,7 @@ class Ability
     # Going forward we should only be using the following actions for CRUD operations: :read, :create,
     # :update, and :destroy. We shouldn't be using :show, :index, :new, or :edit when defining
     # actions or checking abilities. These aliases were made for RESTful actions and since we are
-    # moving away from that, we should stop using them. Eventually, we should remove these aliases.
+    # moving away from that we no longer need to use them.
 
     if user.admin?
       can :manage, :all
@@ -17,8 +17,8 @@ class Ability
       # Permissions all users get
       can [:read, :update], User, id: user.id
       can [:read, :update], User, uid: user.uid
-      can [:index, :show, :create], :term
-      can [:index], DynamicFieldCategory # Need to allow this so we can render EnabledDynamicField pages.
+      can [:read, :create], :term
+      can :read, DynamicFieldCategory # Need to allow this so we can render EnabledDynamicField pages.
 
       # System Wide Permissions
       assign_system_wide_permissions(system_permissions)
@@ -27,14 +27,14 @@ class Ability
       project_permissions.each do |project_id, actions|
         project_string_key = Project.find(project_id).string_key
 
-        can [:index, :read], Project, id: project_id
-        can [:index, :read], Project, string_key: project_string_key
+        can :read, Project, id: project_id
+        can :read, Project, string_key: project_string_key
 
-        can :show, PublishTarget, project_id: project_id
-        can :show, PublishTarget, project: { string_key: project_string_key }
+        can :read, PublishTarget, project_id: project_id
+        can :read, PublishTarget, project: { string_key: project_string_key }
 
-        can :show, FieldSet, project_id: project_id
-        can :show, FieldSet, project: { string_key: project_string_key }
+        can :read, FieldSet, project_id: project_id
+        can :read, FieldSet, project: { string_key: project_string_key }
 
         actions.each do |action|
           send action.to_sym, project_id, project_string_key
@@ -53,7 +53,7 @@ class Ability
         can :manage, :term
         can :manage, :custom_field
       when Permission::READ_ALL_DIGITAL_OBJECTS, Permission::MANAGE_ALL_DIGITAL_OBJECTS
-        can [:show, :index], [Project, PublishTarget, FieldSet]
+        can :read, [Project, PublishTarget, FieldSet]
       end
     end
   end
@@ -99,8 +99,8 @@ class Ability
     can :update, Project, id: project_id
     can :update, Project, string_key: project_string_key
 
-    can [:show, :create, :update, :destroy], FieldSet, project_id: project_id
-    can [:show, :create, :update, :destroy], FieldSet, project: { string_key: project_string_key }
+    can [:read, :create, :update, :destroy], FieldSet, project_id: project_id
+    can [:read, :create, :update, :destroy], FieldSet, project: { string_key: project_string_key }
   end
 
   def read_objects(project_id, project_string_key)
@@ -108,7 +108,7 @@ class Ability
     can :read_objects, Project, { id: project_id }
     can :read_objects, Project, { string_key: project_string_key }
     # and in the context of a specific object where applicable
-    can :show, DigitalObject::Base do |digital_object|
+    can :read, DigitalObject::Base do |digital_object|
       digital_object.projects.detect { |p| p.id.eql?(project_id) }
     end
   end
@@ -124,7 +124,7 @@ class Ability
     can :update_objects, Project, { id: project_id }
     can :update_objects, Project, { string_key: project_string_key }
     # and in the context of a specific object where applicable
-    can [:edit, :update], DigitalObject::Base do |digital_object|
+    can :update, DigitalObject::Base do |digital_object|
       digital_object.projects.detect { |p| p.id.eql?(project_id) || p.string_key.eql?(project_string_key) }
     end
   end

--- a/spec/requests/api/v1/dynamic_field_categories_spec.rb
+++ b/spec/requests/api/v1/dynamic_field_categories_spec.rb
@@ -46,52 +46,46 @@ RSpec.describe 'Dynamic Field Categories Requests', type: :request do
   describe 'GET /api/v1/dynamic_field_categories/:id' do
     let(:dynamic_field_category) { FactoryBot.create(:dynamic_field_category) }
 
-    include_examples 'requires user to have correct permissions' do
-      let(:request) { get "/api/v1/dynamic_field_categories/#{dynamic_field_category.id}" }
-    end
+    before { sign_in_user }
 
-    context 'when logged in user is an administrator' do
-      before { sign_in_user as: :administrator }
-
-      context 'when id is valid' do
-        before do
-          get "/api/v1/dynamic_field_categories/#{dynamic_field_category.id}"
-        end
-
-        it 'returns 200' do
-          expect(response.status).to be 200
-        end
-
-        it 'returns correct response' do
-          expect(response.body).to be_json_eql(%(
-            {
-              "dynamic_field_category": {
-                "display_label": "Descriptive Metadata",
-                "children": [
-
-                ],
-                "sort_order": 3,
-                "type": "DynamicFieldCategory"
-              }
-            }
-          ))
-        end
+    context 'when id is valid' do
+      before do
+        get "/api/v1/dynamic_field_categories/#{dynamic_field_category.id}"
       end
 
-      context 'when id is invalid' do
-        before do
-          get '/api/v1/dynamic_field_categories/1234'
-        end
+      it 'returns 200' do
+        expect(response.status).to be 200
+      end
 
-        it 'returns 404' do
-          expect(response.status).to be 404
-        end
+      it 'returns correct response' do
+        expect(response.body).to be_json_eql(%(
+          {
+            "dynamic_field_category": {
+              "display_label": "Descriptive Metadata",
+              "children": [
 
-        it 'returns correct response' do
-          expect(response.body).to be_json_eql(%(
-            { "errors": [{ "title": "Not Found" }] }
-          ))
-        end
+              ],
+              "sort_order": 3,
+              "type": "DynamicFieldCategory"
+            }
+          }
+        ))
+      end
+    end
+
+    context 'when id is invalid' do
+      before do
+        get '/api/v1/dynamic_field_categories/1234'
+      end
+
+      it 'returns 404' do
+        expect(response.status).to be 404
+      end
+
+      it 'returns correct response' do
+        expect(response.body).to be_json_eql(%(
+          { "errors": [{ "title": "Not Found" }] }
+        ))
       end
     end
   end


### PR DESCRIPTION
We shouldn't use :index, :show, :edit and :new to define permissions. These actions are mapped to one of :read, :update, :create and are really only used for RESTful responses. Once we move everything to graphql we shouldn't need to use them anymore.