### PR TITLE
Allow xml translation array value comparison with new 'equals_any_of' and 'equals_none_of' rules

### DIFF
--- a/lib/hyacinth/xml_generator/element.rb
+++ b/lib/hyacinth/xml_generator/element.rb
@@ -98,8 +98,9 @@ module Hyacinth
       end
 
       # Comparison value given in xml_translation cannot be blank when using
-      # equals/not_equals conditionals. Instead absent/present conditionals
-      # should be used. Additionally, blank field values are never stored.
+      # equals/not_equals equals_any_of/equals_none_of conditionals. Instead
+      # absent/present conditionals should be used. Additionally, blank field
+      # values are never stored.
 
       conditions['equal']&.each do |field_string_key, value_to_compare_to|
         validate_present value_to_compare_to, "comparison value"
@@ -109,6 +110,16 @@ module Hyacinth
       conditions['not_equal']&.each do |field_string_key, value_to_compare_to|
         validate_present value_to_compare_to, "comparison value"
         return false if value_for_field_name(field_string_key, df_data) == value_to_compare_to
+      end
+
+      conditions['equals_any_of']&.each do |field_string_key, array_values_to_compare_to|
+        validate_present array_values_to_compare_to, "comparison values"
+        return false unless array_values_to_compare_to.include?(value_for_field_name(field_string_key, df_data))
+      end
+
+      conditions['equals_none_of']&.each do |field_string_key, array_values_to_compare_to|
+        validate_present array_values_to_compare_to, "comparison values"
+        return false if array_values_to_compare_to.include?(value_for_field_name(field_string_key, df_data))
       end
 
       true

--- a/spec/hyacinth/xml_generator/element_spec.rb
+++ b/spec/hyacinth/xml_generator/element_spec.rb
@@ -171,7 +171,7 @@ describe Hyacinth::XMLGenerator::Element do
     end
 
     context "when checking for fields that are equal" do
-      it 'raises error when doing comparizon with blank value' do
+      it 'raises error when doing comparison with blank value' do
         render_if = { "equal" => { "name_term.uni" => "" } }
         expect { element.render?(render_if, df_data) }.to raise_error ArgumentError
       end
@@ -192,7 +192,7 @@ describe Hyacinth::XMLGenerator::Element do
     end
 
     context "when checking for fields that are not_equal" do
-      it 'raises error when doing comparizon with blank value' do
+      it 'raises error when doing comparison with blank value' do
         render_if = { "not_equal" => { "name_term.uni" => "" } }
         expect { element.render?(render_if, df_data) }.to raise_error ArgumentError
       end
@@ -204,6 +204,54 @@ describe Hyacinth::XMLGenerator::Element do
 
       it "returns true when field does not equal value given" do
         render_if = { "not_equal" => { "name_term.uni" => "jds132" } }
+        expect(element.render?(render_if, df_data)).to be true
+      end
+    end
+
+    context "when checking for fields that are equals_any_of" do
+      it 'raises error when doing comparison with a non-array value' do
+        render_if = { "equals_any_of" => { "name_term.uni" => "" } }
+        expect { element.render?(render_if, df_data) }.to raise_error ArgumentError
+      end
+
+      it 'raises error when doing comparison with an empty array value' do
+        render_if = { "equals_any_of" => { "name_term.uni" => [] } }
+        expect { element.render?(render_if, df_data) }.to raise_error ArgumentError
+      end
+
+      it "returns true when field equals any of the given array values" do
+        render_if = { "equals_any_of" => { "name_term.uni" => ["zzz", "jds1329"], "name_term.value" => ["Salinger, J. D.", "zzz"] } }
+        expect(element.render?(render_if, df_data)).to be true
+      end
+
+      context 'when one field does not eql any of the given array values for that field' do
+        let(:df_data) { dynamic_field_data["name"][1] }
+
+        it "returns false" do
+          render_if = { "equals_any_of" => { "name_term.uni" => ["jds1329"], "name_term.value" => ["zzz"] } }
+          expect(element.render?(render_if, df_data)).to be false
+        end
+      end
+    end
+
+    context "when checking for fields that are equals_none_of" do
+      it 'raises error when doing comparison with a non-array value' do
+        render_if = { "equals_none_of" => { "name_term.uni" => "" } }
+        expect { element.render?(render_if, df_data) }.to raise_error ArgumentError
+      end
+
+      it 'raises error when doing comparison with an empty array value' do
+        render_if = { "equals_none_of" => { "name_term.uni" => [] } }
+        expect { element.render?(render_if, df_data) }.to raise_error ArgumentError
+      end
+
+      it "returns false when field equals any of the array values given" do
+        render_if = { "equals_none_of" => { "name_term.uni" => ["zzz", "jds1329"] } }
+        expect(element.render?(render_if, df_data)).to be false
+      end
+
+      it "returns true when field equals none of array values given" do
+        render_if = { "equals_none_of" => { "name_term.uni" => ["aaa", "bbb"] } }
         expect(element.render?(render_if, df_data)).to be true
       end
     end


### PR DESCRIPTION
@barmintor Same changes as Hyacinth 2, with minor modifications to follow Hyacinth 3 conventions.