### PR TITLE
Moving vocabulary/terms ui queries to use limit/offset

### DIFF
--- a/app/javascript/hyacinth_ui_v1/components/controlled_vocabularies/ControlledVocabularyIndex.js
+++ b/app/javascript/hyacinth_ui_v1/components/controlled_vocabularies/ControlledVocabularyIndex.js
@@ -7,13 +7,13 @@ import ContextualNavbar from '../layout/ContextualNavbar';
 import { vocabularies } from '../../util/hyacinth_api';
 import PaginationBar from '../ui/PaginationBar';
 
-const perPage = 20;
+const limit = 20;
 
 export default class ControlledVocabularyIndex extends React.Component {
   state = {
     controlledVocabularies: [],
     totalRecords: '',
-    page: 1,
+    offset: 0,
   }
 
   componentDidMount() {
@@ -25,17 +25,17 @@ export default class ControlledVocabularyIndex extends React.Component {
   }
 
   vocabulariesFetch = (page) => {
-    vocabularies.all(`page=${page}&per_page=${perPage}`).then((res) => {
+    vocabularies.all(`offset=${limit * (page - 1)}&limit=${limit}`).then((res) => {
       this.setState(produce((draft) => {
         draft.controlledVocabularies = res.data.vocabularies;
         draft.totalRecords = res.data.totalRecords;
-        draft.page = res.data.page;
+        draft.offset = res.data.offset;
       }));
     });
   }
 
   render() {
-    const { controlledVocabularies, totalRecords, page } = this.state;
+    const { controlledVocabularies, totalRecords, offset } = this.state;
 
     return (
       <>
@@ -72,8 +72,8 @@ export default class ControlledVocabularyIndex extends React.Component {
         </Table>
 
         <PaginationBar
-          currentPage={page}
-          perPage={perPage}
+          offset={offset}
+          limit={limit}
           totalItems={totalRecords}
           onPageNumberClick={this.onPageNumberClick}
         />

--- a/app/javascript/hyacinth_ui_v1/components/controlled_vocabularies/terms/TermIndex.js
+++ b/app/javascript/hyacinth_ui_v1/components/controlled_vocabularies/terms/TermIndex.js
@@ -13,12 +13,12 @@ import SearchButton from '../../ui/buttons/SearchButton';
 import PaginationBar from '../../ui/PaginationBar';
 import SelectInput from '../../ui/forms/inputs/SelectInput';
 
-const perPage = '10';
+const limit = 10;
 const defaultFilters = ['authority', 'uri', 'pref_label', 'alt_labels', 'term_type'];
 
 class TermIndex extends React.Component {
   state = {
-    page: '1',
+    offset: 0,
     search: '',
     filters: [],
     terms: [],
@@ -27,9 +27,9 @@ class TermIndex extends React.Component {
 
   componentDidMount() {
     const { match: { params: { stringKey } } } = this.props;
-    const { page, search } = this.state;
+    const { offset, search } = this.state;
 
-    this.termSearch(page, search);
+    this.termSearch(offset, search);
   }
 
   onChange = (name, value) => {
@@ -53,16 +53,17 @@ class TermIndex extends React.Component {
 
     // TODO: Do not search if search term is under three characters AND there are no filters.
 
-    this.termSearch(1, search);
+    this.termSearch(0, search);
   }
 
-  termSearch = (page, search) => {
+  termSearch = (offset, search) => {
     const { match: { params: { stringKey } } } = this.props;
 
-    vocabulary(stringKey).terms().search(`per_page=${perPage}&page=${page}&q=${search}`)
+    vocabulary(stringKey).terms().search(`limit=${limit}&offset=${offset}&q=${search}`)
       .then((res) => {
+        console.log(res)
         this.setState(produce((draft) => {
-          draft.page = page;
+          draft.offset = offset;
           draft.search = search;
           draft.terms = res.data.terms;
           draft.totalRecords = res.data.totalRecords;
@@ -72,12 +73,12 @@ class TermIndex extends React.Component {
 
   onPageNumberClick = (newPage) => {
     const { search } = this.state;
-    this.termSearch(newPage, search)
+    this.termSearch(limit * (newPage - 1), search)
   }
 
   render() {
     const { match: { params: { stringKey } } } = this.props;
-    const { terms, search, filters, page, totalRecords } = this.state;
+    const { terms, search, filters, offset, totalRecords } = this.state;
 
     return (
       <>
@@ -100,7 +101,7 @@ class TermIndex extends React.Component {
                       sm={4}
                       className="pr-1"
                       value={filter[0]}
-                      options={defaultFilters.map(f => ({ value: f, label: f}))}
+                      options={defaultFilters.map(f => ({ value: f, label: f }))}
                     />
                     <TextInput
                       sm={8}
@@ -155,8 +156,8 @@ class TermIndex extends React.Component {
         </Table>
 
         <PaginationBar
-          perPage={perPage}
-          currentPage={page}
+          limit={limit}
+          offset={offset}
           totalItems={totalRecords}
           onPageNumberClick={this.onPageNumberClick}
         />

--- a/app/javascript/hyacinth_ui_v1/components/ui/PaginationBar.js
+++ b/app/javascript/hyacinth_ui_v1/components/ui/PaginationBar.js
@@ -5,11 +5,11 @@ import { Pagination } from 'react-bootstrap';
 class PaginationBar extends React.PureComponent {
   render() {
     const {
-      currentPage, totalItems, perPage, onPageNumberClick,
+      totalItems, onPageNumberClick, limit, offset
     } = this.props;
 
-    const page = Number(currentPage);
-    const totalPages = Math.max(1, Math.ceil(Number(totalItems) / Number(perPage)));
+    const page = (Number(offset) / Number(limit)) + 1;
+    const totalPages = Math.max(1, Math.ceil(Number(totalItems) / Number(limit)));
     const pageNumbers = [];
 
     for (let i = 2; i > 0; i--) {
@@ -67,9 +67,9 @@ class PaginationBar extends React.PureComponent {
 }
 
 PaginationBar.propTypes = {
-  currentPage: PropTypes.number.isRequired,
+  offset: PropTypes.number.isRequired,
   totalItems: PropTypes.number.isRequired,
-  perPage: PropTypes.number.isRequired,
+  limit: PropTypes.number.isRequired,
   onPageNumberClick: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
This is enough to get controlled vocabularies working as expected. The PaginationBar component could probably use a refactor now that it's receiving different parameters. But I didn't want to focus on that just yet.