### PR TITLE
Enable GraphiQL interface for admins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'best_type', '0.0.4'
 gem 'bootsnap', '>= 1.1.0', require: false # Reduces boot times through caching; required in config/boot.rb
 gem 'cancancan', '~> 2.0'
 gem 'devise', '~> 4.6'
+gem 'graphiql-rails'
 gem 'graphql'
 gem 'graphql-errors'
 gem 'jbuilder', '~> 2.5' # Do we need this?
@@ -43,8 +44,6 @@ group :development do
   gem 'capistrano-passenger', '~> 0.1', require: false
   gem 'capistrano-rails', '~> 1.4', require: false
   gem 'capistrano-rvm', '~> 0.1', require: false
-
-  gem 'graphiql-rails'
 
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'listen', '>= 3.0.5', '< 3.2'

--- a/app/graphql/hyacinth_schema.rb
+++ b/app/graphql/hyacinth_schema.rb
@@ -3,7 +3,7 @@
 class HyacinthSchema < GraphQL::Schema
   use GraphQL::Execution::Errors
 
-  max_depth 10
+  max_depth 13
 
   rescue_from(ActiveRecord::RecordNotFound) do |err, _obj, _args, _ctx, _field|
     # Raise a graphql-friendly error with a custom message or we could just send back nil

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,16 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/graphql' if Rails.env.development?
+  # Constraint for restricting certain routes to only admins, or to the development environment
+  dev_or_admin_constraints = lambda do |request|
+    return true if Rails.env.development?
+    current_user = request.env['warden'].user
+    current_user&.is_admin?
+  end
+
+  constraints dev_or_admin_constraints do
+    mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/graphql'
+  end
 
   post "/graphql", to: "graphql#execute"
 


### PR DESCRIPTION
Raise HyacinthSchema max_depth setting from 10 to 13 to accommodate GraphiQL interface needs; Enable GraphiQL interface for admins in non-development environments (but still always allow in development environment).