### PR TITLE
GraphQL Type for Rights and Rights Mutations

### DIFF
--- a/app/graphql/mutations/digital_object/base_rights_mutation.rb
+++ b/app/graphql/mutations/digital_object/base_rights_mutation.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Mutations
+  module DigitalObject
+    class BaseRightsMutation < Mutations::BaseMutation
+      TERM_INPUT_TYPE = GraphQL::InputObjectType.define do
+        name "TermInput"
+
+        argument :prefLabel, !types.String, as: :pref_label
+        argument :altLabels, types[types.String], as: :alt_label
+        argument :authority, types.String
+        argument :uri, !types.String
+        argument :termType, Types::TermCategory.to_non_null_type, as: :term_type
+        argument :customFields, types[Types::CustomFieldAttributes], as: :custom_fields
+      end
+
+      DYNAMIC_FIELD_TYPE_TO_GRAPHQL_INPUT_TYPE = {
+        'string'   => GraphQL::Types::String,
+        'date'     => GraphQL::Types::String,
+        'boolean'  => GraphQL::Types::Boolean,
+        'textarea' => GraphQL::Types::String,
+        'select'   => GraphQL::Types::String,
+        'controlled_term' => TERM_INPUT_TYPE
+      }.freeze
+
+      def self.define_dynamic_field_group_input(dynamic_field_group)
+        GraphQL::InputObjectType.define do
+          name "#{dynamic_field_group[:string_key].camelize(:lower)}Input"
+
+          dynamic_field_group[:children].each do |child|
+            if child[:type] == "DynamicField"
+              argument child[:string_key].camelize(:lower), DYNAMIC_FIELD_TYPE_TO_GRAPHQL_INPUT_TYPE[child[:field_type]], as: child[:string_key]
+            elsif child[:type] == "DynamicFieldGroup"
+              input_type = Mutations::DigitalObject::BaseRightsMutation.define_dynamic_field_group_input(child)
+              argument child[:string_key].camelize(:lower), types[input_type], as: child[:string_key]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/digital_object/update_asset_rights.rb
+++ b/app/graphql/mutations/digital_object/update_asset_rights.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Mutations
+  module DigitalObject
+    class UpdateAssetRights < Mutations::DigitalObject::BaseRightsMutation
+      argument :id, ID, required: true
+
+      Hyacinth::DigitalObject::RightsFields.asset.each do |dynamic_field_group|
+        child_input_type = define_dynamic_field_group_input(dynamic_field_group)
+
+        argument dynamic_field_group[:string_key], [child_input_type], required: false
+      end
+
+      field :asset, Types::DigitalObject::AssetType, null: true
+
+      def resolve(id:, **rights)
+        digital_object = ::DigitalObject::Base.find(id)
+
+        raise "Cannot update item rights for #{digital_object.digital_object_type}" unless digital_object.is_a?(::DigitalObject::Asset)
+
+        ability.authorize! :update_rights, digital_object
+
+        digital_object.rights = rights.deep_transform_values(&:to_h)
+        digital_object.save!(update_index: true, user: context[:current_user])
+
+        { asset: digital_object }
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/digital_object/update_item_rights.rb
+++ b/app/graphql/mutations/digital_object/update_item_rights.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Mutations
+  module DigitalObject
+    class UpdateItemRights < Mutations::DigitalObject::BaseRightsMutation
+      argument :id, ID, required: true
+
+      Hyacinth::DigitalObject::RightsFields.item.each do |dynamic_field_group|
+        child_input_type = define_dynamic_field_group_input(dynamic_field_group)
+
+        argument dynamic_field_group[:string_key], [child_input_type], required: false
+      end
+
+      field :item, Types::DigitalObject::ItemType, null: true
+
+      def resolve(id:, **rights)
+        digital_object = ::DigitalObject::Base.find(id)
+
+        raise "Cannot update item rights for #{digital_object.digital_object_type}" unless digital_object.is_a?(::DigitalObject::Item)
+
+        ability.authorize! :update_rights, digital_object
+
+        digital_object.rights = rights.deep_transform_values(&:to_h)
+        digital_object.save!(update_index: true, user: context[:current_user])
+
+        { item: digital_object }
+      end
+    end
+  end
+end

--- a/app/graphql/types/digital_object/asset_rights_type.rb
+++ b/app/graphql/types/digital_object/asset_rights_type.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module DigitalObject
+    class AssetRightsType < Types::DigitalObject::BaseRights
+      Hyacinth::DigitalObject::RightsFields.asset.each do |dynamic_field_group|
+        object_type = define_dynamic_field_group_type(dynamic_field_group)
+
+        field dynamic_field_group[:string_key], [object_type], null: true
+      end
+    end
+  end
+end

--- a/app/graphql/types/digital_object/asset_type.rb
+++ b/app/graphql/types/digital_object/asset_type.rb
@@ -6,6 +6,7 @@ module Types
       implements Types::DigitalObjectInterface
 
       field :asset_type, Enums::AssetTypeEnum, null: false # enum delegating to BestType library
+      field :rights, Types::DigitalObject::AssetRightsType, null: true
     end
   end
 end

--- a/app/graphql/types/digital_object/base_rights.rb
+++ b/app/graphql/types/digital_object/base_rights.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Types
+  module DigitalObject
+    class BaseRights < Types::BaseObject
+      DYNAMIC_FIELD_TYPE_TO_GRAPHQL_TYPE = {
+        'string'   => GraphQL::Types::String,
+        'date'     => GraphQL::Types::String,
+        'boolean'  => GraphQL::Types::Boolean,
+        'textarea' => GraphQL::Types::String,
+        'select'   => GraphQL::Types::String,
+        'controlled_term' => Types::TermType
+      }.freeze
+
+      def self.define_dynamic_field_group_type(dynamic_field_group)
+        GraphQL::ObjectType.define do
+          name dynamic_field_group[:string_key].camelize
+
+          dynamic_field_group[:children].each do |child|
+            if child[:type] == 'DynamicField'
+              field child[:string_key].camelize(:lower), DYNAMIC_FIELD_TYPE_TO_GRAPHQL_TYPE[child[:field_type]], hash_key: child[:string_key]
+            elsif child[:type] == 'DynamicFieldGroup'
+              field child[:string_key].camelize(:lower), types[Types::DigitalObject::BaseRights.define_dynamic_field_group_type(child)], hash_key: child[:string_key]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/types/digital_object/item_rights_type.rb
+++ b/app/graphql/types/digital_object/item_rights_type.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module DigitalObject
+    class ItemRightsType < Types::DigitalObject::BaseRights
+      Hyacinth::DigitalObject::RightsFields.item.each do |dynamic_field_group|
+        object_type = define_dynamic_field_group_type(dynamic_field_group)
+
+        field dynamic_field_group[:string_key], [object_type], null: true
+      end
+    end
+  end
+end

--- a/app/graphql/types/digital_object/item_type.rb
+++ b/app/graphql/types/digital_object/item_type.rb
@@ -6,6 +6,7 @@ module Types
       implements Types::DigitalObjectInterface
 
       # ... additional fields
+      field :rights, Types::DigitalObject::ItemRightsType, null: true
     end
   end
 end

--- a/app/graphql/types/digital_object_interface.rb
+++ b/app/graphql/types/digital_object_interface.rb
@@ -28,7 +28,6 @@ module Types
     field :first_preserved_at, GraphQL::Types::ISO8601DateTime, null: true
     field :preserved_at, GraphQL::Types::ISO8601DateTime, null: true
     field :parents, [DigitalObjectInterface], null: true
-    field :rights, GraphQL::Types::JSON, null: false
     field :structured_children, DigitalObject::StructuredChildrenType, null: true
     field :publish_entries, [DigitalObject::PublishEntryType], null: true
     field :optimistic_lock_token, String, null: false

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -4,6 +4,9 @@ module Types
   class MutationType < Types::BaseObject
     field :create_asset, mutation: Mutations::CreateAsset
 
+    field :update_item_rights, mutation: Mutations::DigitalObject::UpdateItemRights
+    field :update_asset_rights, mutation: Mutations::DigitalObject::UpdateAssetRights
+
     field :create_user, mutation: Mutations::CreateUser
     field :update_user, mutation: Mutations::UpdateUser
 

--- a/app/javascript/hyacinth_ui_v1/components/digital_objects/rights/rights_form/ItemRightsForm.js
+++ b/app/javascript/hyacinth_ui_v1/components/digital_objects/rights/rights_form/ItemRightsForm.js
@@ -22,18 +22,20 @@ import RightsForWorksOfArtSculptureAndPhotographs from './subsections/RightsForW
 import UnderlyingRights from './subsections/UnderlyingRights';
 import defaultItemRights from './defaultItemRights';
 
+const useHash = (initialHash) => {
+  const [hash, setHash] = useState(initialHash);
+
+  const setHashViaKey = (key, value) => setHash(produce(hash, (draft) => { draft[key] = value; }));
+
+  return [hash, setHashViaKey];
+};
+
 function ItemRightsForm(props) {
-  const { digitalObject } = props;
-  const { id, rights: initialRights, dynamicFieldData } = digitalObject;
+  const { digitalObject: { id, rights: initialRights, dynamicFieldData } } = props;
   const history = useHistory();
 
   const camelizedInitialRights = keyTransformer.deepCamelCase(initialRights);
-  const [rights, setRights] = useState(merge({}, defaultItemRights(), camelizedInitialRights));
-  const onChange = (subsection, value) => {
-    setRights(produce(rights, (draft) => {
-      draft[subsection] = value;
-    }));
-  };
+  const [rights, setRights] = useHash(merge({}, defaultItemRights(), camelizedInitialRights));
 
   const onSubmitHandler = () => {
     return digitalObjectApi.rights.update(
@@ -59,19 +61,19 @@ function ItemRightsForm(props) {
       <DescriptiveMetadata
         dynamicFieldData={dynamicFieldData}
         value={descriptiveMetadata}
-        onChange={v => onChange('descriptiveMetadata', v)}
+        onChange={v => setRights('descriptiveMetadata', v)}
       />
 
       <CopyrightStatus
         value={copyrightStatus}
-        onChange={v => onChange('copyrightStatus', v)}
+        onChange={v => setRights('copyrightStatus', v)}
       />
 
       <InputGroup>
         <Label sm={4} align="right">Is there additional copyright or permissions information to record?</Label>
         <BooleanRadioButtons
           value={additionalRightsToRecord.enabled}
-          onChange={v => onChange('additionalRightsToRecord', { enabled: v })}
+          onChange={v => setRights('additionalRightsToRecord', { enabled: v })}
         />
       </InputGroup>
 
@@ -79,37 +81,37 @@ function ItemRightsForm(props) {
         <div>
           <CopyrightOwnership
             value={copyrightOwnership}
-            onChange={v => onChange('copyrightOwnership', v)}
+            onChange={v => setRights('copyrightOwnership', v)}
           />
 
           <ColumbiaUniversityIsCopyrightHolder
             value={columbiaUniversityIsCopyrightHolder}
-            onChange={v => onChange('columbiaUniversityIsCopyrightHolder', v)}
+            onChange={v => setRights('columbiaUniversityIsCopyrightHolder', v)}
           />
 
           <LicensedToColumbiaUniversity
             value={licensedToColumbiaUniversity}
-            onChange={v => onChange('licensedToColumbiaUniversity', v)}
+            onChange={v => setRights('licensedToColumbiaUniversity', v)}
           />
 
           <ContractualLimitationsRestrictionsAndPermissions
             audioVisualContent={descriptiveMetadata.typeOfContent === 'motion_picture'}
             value={contractualLimitationsRestrictionsAndPermissions}
-            onChange={v => onChange('contractualLimitationsRestrictionsAndPermissions', v)}
+            onChange={v => setRights('contractualLimitationsRestrictionsAndPermissions', v)}
           />
 
           {
             descriptiveMetadata.typeOfContent === 'pictoral_graphic_and_scuptural' && (
               <RightsForWorksOfArtSculptureAndPhotographs
                 value={rightsForWorksOfArtSculptureAndPhotographs}
-                onChange={v => onChange('rightsForWorksOfArtSculptureAndPhotographs', v)}
+                onChange={v => setRights('rightsForWorksOfArtSculptureAndPhotographs', v)}
               />
             )
           }
 
           <UnderlyingRights
             value={underlyingRights}
-            onChange={v => onChange('underlyingRights', v)}
+            onChange={v => setRights('underlyingRights', v)}
           />
         </div>
       </Collapse>

--- a/lib/hyacinth/digital_object/rights_fields.rb
+++ b/lib/hyacinth/digital_object/rights_fields.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/ModuleLength, Metrics/MethodLength
+module Hyacinth
+  module DigitalObject
+    module RightsFields
+      # Returns list of mock dynamic field group definitions for the rights item form.
+      #
+      # This is temporary solution to help generate the GraphQL types for item rights. Eventually, we will want to move
+      # towards creating dynamic field group and dynamic field definitions for these fields. This will help us expose
+      # field configuration to the UI, so that the item rights form can generate fields based on their configuration.
+      def self.item
+        [
+          {
+            type: "DynamicFieldGroup",
+            string_key: "descriptive_metadata",
+            children: [
+              { string_key: "type_of_content", field_type: "select", select_options: "{}", type: "DynamicField" },
+              { string_key: "country_of_origin", field_type: "controlled_term", controlled_vocabulary: "geonames", type: "DynamicField" },
+              { string_key: "film_distributed_to_public", field_type: "boolean", type: "DynamicField" },
+              { string_key: "film_distributed_commercially", field_type: "boolean", type: "DynamicField" }
+            ]
+          },
+          {
+            type: "DynamicFieldGroup",
+            string_key: "copyright_status",
+            is_repeatable: false,
+            children: [
+              { string_key: "copyright_statement", field_type: "controlled_term", controlled_vocabulary: "rights_statement", type: "DynamicField" },
+              { string_key: "copyright_notes", field_type: "textarea", type: "DynamicField" },
+              { string_key: "copyright_registered", field_type: "boolean", type: "DynamicField" },
+              { string_key: "copyright_renewed", field_type: "boolean", type: "DynamicField" },
+              { string_key: "copyright_date_of_renewal", field_type: "date", type: "DynamicField" },
+              { string_key: "copyright_expiration_date", field_type: "date", type: "DynamicField" },
+              { string_key: "cul_copyright_assessment_date", field_type: "date", type: "DynamicField" }
+            ]
+          },
+          {
+            type: "DynamicFieldGroup",
+            string_key: "copyright_ownership",
+            is_repeatable: true,
+            children: [
+              { string_key: "name", field_type: "controlled_term", controlled_vocabulary: "name", type: "DynamicField" },
+              { string_key: "heirs", field_type: "string", type: "DynamicField" },
+              { string_key: "contact_information", field_type: "textarea", type: "DynamicField" }
+            ]
+          },
+          {
+            type: "DynamicFieldGroup",
+            string_key: "columbia_university_is_copyright_holder",
+            is_repeatable: false,
+            children: [
+              { string_key: "date_of_transfer", field_type: "date", type: "DynamicField" },
+              { string_key: "date_of_expiration", field_type: "date", type: "DynamicField" },
+              { string_key: "transfer_documentation", field_type: "string", type: "DynamicField" },
+              { string_key: "other_transfer_evidence", field_type: "string", type: "DynamicField" },
+              { string_key: "transfer_documentation_note", field_type: "string", type: "DynamicField" }
+            ]
+          },
+          {
+            type: "DynamicFieldGroup",
+            string_key: "licensed_to_columbia_university",
+            is_repeatable: false,
+            children: [
+              { string_key: "date_of_license", field_type: "date", type: "DynamicField" },
+              { string_key: "termination_date_of_license", field_type: "date", type: "DynamicField" },
+              { string_key: "credits", field_type: "string", type: "DynamicField" },
+              { string_key: "acknowledgements", field_type: "string", type: "DynamicField" },
+              { string_key: "license_documentation_location", field_type: "string", type: "DynamicField" }
+            ]
+          },
+          {
+            type: "DynamicFieldGroup",
+            string_key: "rights_for_works_of_art_sculpture_and_photographs",
+            is_repeatable: false,
+            children: [
+              { string_key: "publicity_rights_present", field_type: "string", type: "DynamicField" },
+              { string_key: "trademarks_prominently_visible", field_type: "boolean", type: "DynamicField" },
+              { string_key: "sensitive_in_nature", field_type: "boolean", type: "DynamicField" },
+              { string_key: "privacy_concerns", field_type: "boolean", type: "DynamicField" },
+              { string_key: "children_materially_identifiable_in_work", field_type: "boolean", type: "DynamicField" },
+              { string_key: "vara_rights_concerns", field_type: "boolean", type: "DynamicField" },
+              { string_key: "note", field_type: "string", type: "DynamicField" }
+            ]
+          },
+          {
+            type: "DynamicFieldGroup",
+            string_key: "contractual_limitations_restrictions_and_permissions",
+            children: [
+              { string_key: "option_a", field_type: "boolean", type: "DynamicField" },
+              { string_key: "option_b", field_type: "boolean", type: "DynamicField" },
+              { string_key: "option_c", field_type: "boolean", type: "DynamicField" },
+              { string_key: "option_d", field_type: "boolean", type: "DynamicField" },
+              { string_key: "option_e", field_type: "boolean", type: "DynamicField" },
+              { string_key: "option_av_a", field_type: "boolean", type: "DynamicField" },
+              { string_key: "option_av_b", field_type: "boolean", type: "DynamicField" },
+              { string_key: "option_av_c", field_type: "boolean", type: "DynamicField" },
+              { string_key: "option_av_d", field_type: "boolean", type: "DynamicField" },
+              { string_key: "option_av_e", field_type: "boolean", type: "DynamicField" },
+              { string_key: "option_av_f", field_type: "boolean", type: "DynamicField" },
+              { string_key: "option_av_g", field_type: "boolean", type: "DynamicField" },
+              { string_key: "reproduction_and_distribution_prohibited_until", field_type: "date", type: "DynamicField" },
+              { string_key: "photographic_or_film_credit", field_type: "string", type: "DynamicField" },
+              { string_key: "excerpt_limited_to", field_type: "string", type: "DynamicField" },
+              { string_key: "other", field_type: "string", type: "DynamicField" },
+              {
+                type: "DynamicFieldGroup",
+                string_key: "permissions_granted_as_part_of_the_use_license",
+                field_type: "select",
+                children: [
+                  { string_key: "value", field_type: "select", type: "DynamicField" } # MultiSelect
+                ]
+              }
+            ]
+          },
+          {
+            type: "DynamicFieldGroup",
+            string_key: "underlying_rights",
+            children: [
+              { string_key: "note", field_type: "string", type: "DynamicField" },
+              { string_key: "talent_rights", field_type: "select", type: "DynamicField" },
+              { string_key: "columbia_music_license", field_type: "select", type: "DynamicField" },
+              { string_key: "composition", field_type: "string", type: "DynamicField" },
+              { string_key: "recording", field_type: "string", type: "DynamicField" },
+              {
+                type: "DynamicFieldGroup",
+                string_key: "other_underlying_rights",
+                is_repeatable: true,
+                children: [
+                  { string_key: "value", field_type: "select", type: "DynamicField" } # MultiSelect
+                ]
+              },
+              { string_key: "other", field_type: "string", type: "DynamicField" }
+            ]
+          }
+        ]
+      end
+
+      def self.asset
+        [
+          {
+            type: "DynamicFieldGroup",
+            string_key: "restriction_on_access",
+            is_repeatable: true,
+            children: [
+              { string_key: "value", field_type: "select", type: "DynamicField" },
+              { string_key: "embargo_release", field_type: "date", type: "DynamicField" },
+              {
+                type: "DynamicFieldGroup",
+                string_key: "location",
+                is_repeatable: true,
+                children: [
+                  { string_key: "term", field_type: "controlled_term", controlled_vocabulary: "location", type: "DynamicField" }
+                ]
+              },
+              {
+                type: "DynamicFieldGroup",
+                string_key: "affiliation",
+                is_repeatable: true,
+                children: [
+                  { string_key: "value", field_type: "string", type: "DynamicField" }
+                ]
+              },
+              { string_key: "note", field_type: "string", type: "DynamicField" }
+            ]
+          },
+          {
+            type: "DynamicFieldGroup",
+            string_key: "copyright_status_override",
+            is_repeatable: false,
+            children: [
+              { string_key: "copyright_statement", field_type: "controlled_term", controlled_vocabulary: "rights_statement", type: "DynamicField" },
+              { string_key: "copyright_notes", field_type: "textarea", type: "DynamicField" },
+              { string_key: "copyright_registered", field_type: "boolean", type: "DynamicField" },
+              { string_key: "copyright_renewed", field_type: "boolean", type: "DynamicField" },
+              { string_key: "copyright_date_of_renewal", field_type: "date", type: "DynamicField" },
+              { string_key: "copyright_expiration_date", field_type: "date", type: "DynamicField" },
+              { string_key: "cul_copyright_assessment_date", field_type: "date", type: "DynamicField" }
+            ]
+          }
+        ]
+      end
+    end
+  end
+end
+# rubocop:enable Metrics/ModuleLength, Metrics/MethodLength

--- a/spec/factories/digital_objects/items.rb
+++ b/spec/factories/digital_objects/items.rb
@@ -18,7 +18,9 @@ FactoryBot.define do
       instance.instance_variable_set(
         '@rights',
         {
-          'rights_field' => 'rights value'
+          'descriptive_metadata' => [
+            { 'type_of_content' => 'literary' }
+          ]
         }
       )
       instance

--- a/spec/requests/graphql/mutations/digital_object/update_asset_rights_mutation_spec.rb
+++ b/spec/requests/graphql/mutations/digital_object/update_asset_rights_mutation_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Updating Asset Rights', type: :request do
+  let(:authorized_item) { FactoryBot.create(:item, :with_primary_project) }
+  let(:authorized_project) { authorized_item.primary_project }
+  let(:authorized_asset) { FactoryBot.create(:asset, parent: authorized_item) }
+
+  include_examples 'requires user to have correct permissions for graphql request' do
+    let(:variables) { { input: { id: authorized_asset.uid } } }
+    let(:request) { graphql query, variables }
+  end
+
+  context "when logged in user has appropriate permissions" do
+    let(:variables) do
+      {
+        input: {
+          id: authorized_asset.uid,
+          copyrightStatusOverride: [{
+            copyrightStatement: {
+              prefLabel: "In Copyright",
+              termType: "external",
+              uri: "https://example.com/term/in_copyright"
+            },
+            copyrightNotes: "No Copyright Notes",
+            copyrightRegistered: false,
+            copyrightRenewed: false,
+            copyrightDateOfRenewal: "2001-01-01",
+            copyrightExpirationDate: "2001-01-01",
+            culCopyrightAssessmentDate: "2001-01-01"
+          }],
+          restrictionOnAccess: [{
+            value: "Open",
+            embargoRelease: "2001-01-01",
+            location: [{
+              term: {
+                prefLabel: "Great Location",
+                termType: "external",
+                uri: "https://example.com/great_location"
+              }
+            }],
+            affiliation: [
+              { value: "something" }
+            ],
+            note: "restriction note"
+          }]
+        }
+      }
+    end
+
+    let(:expected_rights) do
+      variables[:input].except(:id).deep_transform_keys { |k| k.to_s.underscore }
+    end
+
+    let(:expected_response) do
+      %(
+        {
+          "id": "#{authorized_asset.uid}",
+          "rights": {
+            "copyrightStatusOverride": [
+              {
+                "copyrightStatement": {
+                  "prefLabel": "In Copyright",
+                  "termType": "external",
+                  "uri": "https://example.com/term/in_copyright"
+                }
+              }
+            ]
+          }
+        }
+      )
+    end
+
+    before do
+      sign_in_project_contributor to: [:read_objects, :assess_rights], project: authorized_project
+      graphql query, variables
+    end
+
+    it "return a asset with the expected rights fields" do
+      expect(response.body).to be_json_eql(expected_response).at_path('data/updateAssetRights/asset')
+    end
+
+    it 'sets rights fields' do
+      expect(DigitalObject::Base.find(authorized_asset.uid).rights).to match expected_rights
+    end
+  end
+
+  def query
+    <<~GQL
+      mutation ($input: UpdateAssetRightsInput!) {
+        updateAssetRights(input: $input) {
+          asset {
+            id
+            rights {
+              copyrightStatusOverride {
+                copyrightStatement {
+                  prefLabel
+                  uri
+                  termType
+                }
+              }
+            }
+          }
+        }
+      }
+    GQL
+  end
+end

--- a/spec/requests/graphql/mutations/digital_object/update_item_rights_mutation_spec.rb
+++ b/spec/requests/graphql/mutations/digital_object/update_item_rights_mutation_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Updating Item Rights', type: :request do
+  let(:authorized_object) { FactoryBot.create(:item, :with_primary_project) }
+  let(:authorized_project) { authorized_object.primary_project }
+
+  include_examples 'requires user to have correct permissions for graphql request' do
+    let(:variables) { { input: { id: authorized_object.uid } } }
+    let(:request) { graphql query, variables }
+  end
+
+  context "when logged in user has appropriate permissions" do
+    let(:variables) do
+      {
+        input: {
+          id: authorized_object.uid,
+          descriptiveMetadata: [{
+            typeOfContent: "motion_picture",
+            countryOfOrigin: {
+              prefLabel: "United States",
+              termType: "external",
+              uri: "https://example.com/term/united_states"
+            },
+            filmDistributedToPublic: true,
+            filmDistributedCommercially: true
+          }],
+          copyrightStatus: [{
+            copyrightStatement: {
+              prefLabel: "In Copyright",
+              termType: "external",
+              uri: "https://example.com/term/in_copyright"
+            },
+            copyrightNotes: "No Copyright Notes",
+            copyrightRegistered: false,
+            copyrightRenewed: false,
+            copyrightDateOfRenewal: "2001-01-01",
+            copyrightExpirationDate: "2001-01-01",
+            culCopyrightAssessmentDate: "2001-01-01"
+          }],
+          copyrightOwnership: [{
+            name: {
+              prefLabel: "Random, Person",
+              termType: "external",
+              uri: "https://example.com/term/random,person"
+            },
+            heirs: "No Heirs",
+            contactInformation: "No Contact Information"
+          }],
+          columbiaUniversityIsCopyrightHolder: [{
+            dateOfTransfer: "2001-01-01",
+            dateOfExpiration: "2001-01-01",
+            transferDocumentation: "None",
+            otherTransferEvidence: "None",
+            transferDocumentationNote: "No Notes"
+          }],
+          licensedToColumbiaUniversity: [{
+            dateOfLicense: "2002-01-01",
+            terminationDateOfLicense: "2002-02-02",
+            credits: "No credits",
+            acknowledgements: "No acknowledgements",
+            licenseDocumentationLocation: "Unknown"
+          }],
+          contractualLimitationsRestrictionsAndPermissions: [{
+            optionA: true,
+            optionB: false,
+            optionC: true,
+            optionD: false,
+            optionE: false,
+            optionAvA: false,
+            optionAvB: false,
+            optionAvC: false,
+            optionAvD: false,
+            optionAvE: false,
+            optionAvF: true,
+            optionAvG: false,
+            reproductionAndDistributionProhibitedUntil: "2010-01-01",
+            photographicOrFilmCredit: "No Credits",
+            excerptLimitedTo: "23 minutes",
+            other: "None",
+            permissionsGrantedAsPartOfTheUseLicense: [{ value: "No permissions" }]
+          }],
+          underlyingRights: [{
+            note: "No underlying rights",
+            talentRights: "No talent rights",
+            columbiaMusicLicense: "Master recording license",
+            composition: "none",
+            recording: "none",
+            otherUnderlyingRights: [{ value: "VARA rights" }],
+            other: "no other"
+          }]
+        }
+      }
+    end
+
+    let(:expected_rights) do
+      variables[:input].except(:id).deep_transform_keys { |k| k.to_s.underscore }
+    end
+
+    let(:expected_response) do
+      %(
+        {
+          "id": "#{authorized_object.uid}",
+          "rights": {
+            "descriptiveMetadata": [
+              {
+                "typeOfContent": "motion_picture"
+              }
+            ]
+          }
+        }
+      )
+    end
+
+    before do
+      sign_in_project_contributor to: [:read_objects, :assess_rights], project: authorized_project
+      graphql query, variables
+    end
+
+    it "return a single item with the expected rights fields" do
+      expect(response.body).to be_json_eql(expected_response).at_path('data/updateItemRights/item')
+    end
+
+    it 'sets rights fields' do
+      expect(DigitalObject::Base.find(authorized_object.uid).rights).to match expected_rights
+    end
+  end
+
+  def query
+    <<~GQL
+      mutation ($input: UpdateItemRightsInput!) {
+        updateItemRights(input: $input) {
+          item {
+            id
+            rights {
+              descriptiveMetadata {
+                typeOfContent
+              }
+            }
+          }
+        }
+      }
+    GQL
+  end
+end

--- a/spec/requests/graphql/query/digital_object_spec.rb
+++ b/spec/requests/graphql/query/digital_object_spec.rb
@@ -61,7 +61,11 @@ RSpec.describe 'Retrieving Digital Object', type: :request do
           ],
           "publishEntries": [],
           "rights": {
-            "rights_field": "rights value"
+            "descriptiveMetadata": [
+              {
+                "typeOfContent": "literary"
+              }
+            ]
           },
           "serializationVersion": "1",
           "state": "active",
@@ -136,7 +140,14 @@ RSpec.describe 'Retrieving Digital Object', type: :request do
             }
           }
           optimisticLockToken
-          rights
+
+          ... on Item {
+            rights {
+              descriptiveMetadata {
+                typeOfContent
+              }
+            }
+          }
         }
       }
     GQL


### PR DESCRIPTION
- Generating GraphQL Types from mock dynamic fields hash.
- Added two mutations, one to update item rights and one to update asset rights