### PR TITLE
Using id as identifier instead of string key for dynamic field groups and dynamic fields

### DIFF
--- a/app/graphql/mutations/delete_dynamic_field.rb
+++ b/app/graphql/mutations/delete_dynamic_field.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class Mutations::DeleteDynamicField < Mutations::BaseMutation
-  argument :string_key, ID, required: true
+  argument :id, ID, required: true
 
   field :dynamic_field, Types::DynamicFieldType, null: true
 
-  def resolve(string_key:)
-    dynamic_field = DynamicField.find_by!(string_key: string_key)
+  def resolve(id:)
+    dynamic_field = DynamicField.find(id)
 
     ability.authorize! :delete, dynamic_field
 

--- a/app/graphql/mutations/delete_dynamic_field_group.rb
+++ b/app/graphql/mutations/delete_dynamic_field_group.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class Mutations::DeleteDynamicFieldGroup < Mutations::BaseMutation
-  argument :string_key, ID, required: true
+  argument :id, ID, required: true
 
   field :dynamic_field_group, Types::DynamicFieldGroupType, null: true
 
-  def resolve(string_key:)
-    dynamic_field_group = DynamicFieldGroup.find_by!(string_key: string_key)
+  def resolve(id:)
+    dynamic_field_group = DynamicFieldGroup.find(id)
 
     ability.authorize! :delete, dynamic_field_group
 

--- a/app/graphql/mutations/update_dynamic_field.rb
+++ b/app/graphql/mutations/update_dynamic_field.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class Mutations::UpdateDynamicField < Mutations::BaseMutation
-  argument :string_key, ID, required: true
+  argument :id, ID, required: true
   argument :display_label, String, required: false
   argument :field_type, String, required: false
   argument :sort_order, Integer, required: false
@@ -14,8 +14,8 @@ class Mutations::UpdateDynamicField < Mutations::BaseMutation
 
   field :dynamic_field, Types::DynamicFieldType, null: true
 
-  def resolve(string_key:, **attributes)
-    dynamic_field = DynamicField.find_by!(string_key: string_key)
+  def resolve(id:, **attributes)
+    dynamic_field = DynamicField.find(id)
 
     ability.authorize! :update, dynamic_field
 

--- a/app/graphql/mutations/update_dynamic_field_group.rb
+++ b/app/graphql/mutations/update_dynamic_field_group.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Mutations::UpdateDynamicFieldGroup < Mutations::BaseMutation
-  argument :string_key, ID, required: true
+  argument :id, ID, required: true
   argument :display_label, String, required: false
   argument :sort_order, Integer, required: false
   argument :is_repeatable, Boolean, required: false
@@ -9,8 +9,8 @@ class Mutations::UpdateDynamicFieldGroup < Mutations::BaseMutation
 
   field :dynamic_field_group, Types::DynamicFieldGroupType, null: true
 
-  def resolve(string_key:, **attributes)
-    dynamic_field_group = DynamicFieldGroup.find_by!(string_key: string_key)
+  def resolve(id:, **attributes)
+    dynamic_field_group = DynamicFieldGroup.find(id)
 
     ability.authorize! :update, dynamic_field_group
 

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -52,6 +52,18 @@ module Types
       description "List of all vocabularies"
     end
 
+    field :dynamic_field_categories, [DynamicFieldCategoryType], null: true do
+      description "List of all dynamic field categories"
+    end
+
+    field :dynamic_field_group, DynamicFieldGroupType, null: true do
+      argument :id, ID, required: true
+    end
+
+    field :dynamic_field, DynamicFieldType, null: true do
+      argument :id, ID, required: true
+    end
+
     def digital_objects
       # This is a temporary implementation, this should actually querying solr
       # and considering object read permissions.
@@ -86,10 +98,6 @@ module Types
       }
     end
 
-    field :dynamic_field_categories, [DynamicFieldCategoryType], null: true do
-      description "List of all dynamic field categories"
-    end
-
     def dynamic_field_categories
       ability.authorize!(:read, DynamicFieldCategory)
       DynamicFieldCategory.order(:sort_order)
@@ -105,22 +113,14 @@ module Types
       dynamic_field_category
     end
 
-    field :dynamic_field_group, DynamicFieldGroupType, null: true do
-      argument :string_key, ID, required: true
-    end
-
-    def dynamic_field_group(string_key:)
-      dynamic_field_group = DynamicFieldGroup.find_by!(string_key: string_key)
+    def dynamic_field_group(id:)
+      dynamic_field_group = DynamicFieldGroup.find(id)
       ability.authorize!(:read, dynamic_field_group)
       dynamic_field_group
     end
 
-    field :dynamic_field, DynamicFieldType, null: true do
-      argument :string_key, ID, required: true
-    end
-
-    def dynamic_field(string_key:)
-      dynamic_field = DynamicField.find_by!(string_key: string_key)
+    def dynamic_field(id:)
+      dynamic_field = DynamicField.find(id)
       ability.authorize!(:read, dynamic_field)
       dynamic_field
     end

--- a/app/javascript/hyacinth_v1/components/dynamic_fields/DynamicFieldIndex.js
+++ b/app/javascript/hyacinth_v1/components/dynamic_fields/DynamicFieldIndex.js
@@ -33,7 +33,6 @@ import { Table } from 'react-bootstrap';
           stringKey
           displayLabel
           sortOrder
-          exportRules
           children {
             type: __typename
             ... on DynamicFieldGroup {id}

--- a/spec/requests/graphql/mutations/delete_dynamic_field_group_spec.rb
+++ b/spec/requests/graphql/mutations/delete_dynamic_field_group_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Mutations::DeleteDynamicFieldGroup, type: :request do
   let(:dynamic_field_group) { FactoryBot.create(:dynamic_field_group) }
 
   include_examples 'requires user to have correct permissions for graphql request' do
-    let(:variables) { { input: { stringKey: dynamic_field_group.string_key } } }
+    let(:variables) { { input: { id: dynamic_field_group.id } } }
     let(:request) { graphql query, variables }
   end
 
@@ -15,20 +15,20 @@ RSpec.describe Mutations::DeleteDynamicFieldGroup, type: :request do
 
     context 'when deleting a dynamic field group that exists' do
       before do
-        graphql query, input: { stringKey: dynamic_field_group.string_key }
+        graphql query, input: { id: dynamic_field_group.id }
       end
 
       it 'deletes record from database' do
-        expect(DynamicFieldGroup.find_by(string_key: dynamic_field_group.string_key)).to be nil
+        expect(DynamicFieldGroup.find_by(id: dynamic_field_group.id)).to be nil
       end
     end
 
     context 'when deleting a dynamic field group that does not exist' do
-      before { graphql query, input: { stringKey: 'invalid-string-key' } }
+      before { graphql query, input: { id: 'invalid-id' } }
 
       it 'returns errors' do
         expect(response.body).to be_json_eql(%(
-          "Couldn't find DynamicFieldGroup"
+          "Couldn't find DynamicFieldGroup with 'id'=invalid-id"
         )).at_path('errors/0/message')
       end
     end

--- a/spec/requests/graphql/mutations/delete_dynamic_field_spec.rb
+++ b/spec/requests/graphql/mutations/delete_dynamic_field_spec.rb
@@ -6,40 +6,41 @@ RSpec.describe Mutations::DeleteDynamicField, type: :request do
   let(:dynamic_field) { FactoryBot.create(:dynamic_field) }
 
   include_examples 'requires user to have correct permissions for graphql request' do
-    let(:request) { graphql query, input: { stringKey: dynamic_field.string_key } }
+    let(:request) { graphql query, input: { id: dynamic_field.id } }
   end
 
   context 'when logged in user is an administrator' do
     before { sign_in_user as: :administrator }
 
     context 'when deleting a dynamic_field that exists' do
-      let(:stringKey) { dynamic_field.string_key }
+      let(:id) { dynamic_field.id }
       before do
-        graphql query, input: { stringKey: stringKey }
+        graphql query, input: { id: id }
       end
 
       it 'deletes record from database' do
-        expect(DynamicField.find_by(string_key: stringKey)).to be nil
+        expect(DynamicField.find_by(id: id)).to be nil
       end
     end
 
     context 'when deleting a dynamic_field that does not exist' do
       before do
-        graphql query, input: { stringKey: "invalid-key" }
+        graphql query, input: { id: "invalid-key" }
       end
       it 'returns errors' do
         expect(response.body).to be_json_eql(%(
-          "Couldn't find DynamicField"
+          "Couldn't find DynamicField with 'id'=invalid-key"
         )).at_path('errors/0/message')
       end
     end
   end
+
   def query
     <<~GQL
     mutation ($input: DeleteDynamicFieldInput!) {
       deleteDynamicField(input: $input) {
         dynamicField {
-          stringKey
+          id
         }
       }
     }

--- a/spec/requests/graphql/mutations/update_dynamic_field_group_spec.rb
+++ b/spec/requests/graphql/mutations/update_dynamic_field_group_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Mutations::UpdateDynamicFieldGroup, type: :request do
   let(:dynamic_field_group) { FactoryBot.create(:dynamic_field_group, :with_export_rule) }
 
   include_examples 'requires user to have correct permissions for graphql request' do
-    let(:variables) { { input: { stringKey: dynamic_field_group.string_key, displayLabel: 'Best Dynamic Field Group', sortOrder: 1, isRepeatable: true } } }
+    let(:variables) { { input: { id: dynamic_field_group.id, displayLabel: 'Best Dynamic Field Group', sortOrder: 1, isRepeatable: true } } }
     let(:request) { graphql query, variables }
   end
 
@@ -15,7 +15,7 @@ RSpec.describe Mutations::UpdateDynamicFieldGroup, type: :request do
 
     context 'when updating display label' do
       let(:variables) do
-        { input: { stringKey: dynamic_field_group.string_key, displayLabel: 'Best Dynamic Field Group' } }
+        { input: { id: dynamic_field_group.id, displayLabel: 'Best Dynamic Field Group' } }
       end
 
       before { graphql query, variables }
@@ -28,7 +28,7 @@ RSpec.describe Mutations::UpdateDynamicFieldGroup, type: :request do
 
     context 'when updating sort order' do
       let(:variables) do
-        { input: { stringKey: dynamic_field_group.string_key, sortOrder: 3 } }
+        { input: { id: dynamic_field_group.id, sortOrder: 3 } }
       end
 
       before { graphql query, variables }
@@ -41,7 +41,7 @@ RSpec.describe Mutations::UpdateDynamicFieldGroup, type: :request do
 
     context 'when updating is repeatable' do
       let(:variables) do
-        { input: { stringKey: dynamic_field_group.string_key, isRepeatable: false } }
+        { input: { id: dynamic_field_group.id, isRepeatable: false } }
       end
 
       before { graphql query, variables }
@@ -56,7 +56,7 @@ RSpec.describe Mutations::UpdateDynamicFieldGroup, type: :request do
       let(:variables) do
         {
           input: {
-            stringKey: dynamic_field_group.string_key,
+            id: dynamic_field_group.id,
             exportRules: [
               {
                 id: dynamic_field_group.export_rules.first.id,

--- a/spec/requests/graphql/mutations/update_dynamic_field_spec.rb
+++ b/spec/requests/graphql/mutations/update_dynamic_field_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Mutations::UpdateDynamicField, type: :request do
   let(:dynamic_field) { FactoryBot.create(:dynamic_field) }
 
   include_examples 'requires user to have correct permissions for graphql request' do
-    let(:variables) { { input: { stringKey: dynamic_field.string_key, displayLabel: 'New Location' } } }
+    let(:variables) { { input: { id: dynamic_field.id, displayLabel: 'New Location' } } }
     let(:request) { graphql query, variables }
   end
 
@@ -17,7 +17,7 @@ RSpec.describe Mutations::UpdateDynamicField, type: :request do
       let(:variables) do
         {
           input: {
-            stringKey: dynamic_field.string_key,
+            id: dynamic_field.id,
             displayLabel: 'New Location'
           }
         }
@@ -34,7 +34,7 @@ RSpec.describe Mutations::UpdateDynamicField, type: :request do
       let(:variables) do
         {
           input: {
-            stringKey: dynamic_field.string_key,
+            id: dynamic_field.id,
             controlledVocabulary: 'vocabulary2'
           }
         }
@@ -51,7 +51,7 @@ RSpec.describe Mutations::UpdateDynamicField, type: :request do
       let(:variables) do
         {
           input: {
-            stringKey: dynamic_field.string_key,
+            id: dynamic_field.id,
             selectOptions: '[{"value":"val1","display_label":"Value 1"}, {"value":"val2","display_label":"Value 2"}]'
           }
         }
@@ -68,7 +68,7 @@ RSpec.describe Mutations::UpdateDynamicField, type: :request do
       let(:variables) do
         {
           input: {
-            stringKey: dynamic_field.string_key,
+            id: dynamic_field.id,
             isTitleSearchable: true
           }
         }
@@ -85,7 +85,7 @@ RSpec.describe Mutations::UpdateDynamicField, type: :request do
       let(:variables) do
         {
           input: {
-            stringKey: dynamic_field.string_key,
+            id: dynamic_field.id,
             displayLabel: 'New Location',
             fieldType: 'not-valid'
           }

--- a/spec/requests/graphql/query/dynamic_field_group_spec.rb
+++ b/spec/requests/graphql/query/dynamic_field_group_spec.rb
@@ -6,35 +6,35 @@ RSpec.describe 'Retrieving Dynamic Field Group', type: :request do
   let(:dynamic_field_group) { FactoryBot.create(:dynamic_field_group) }
 
   include_examples 'requires user to have correct permissions for graphql request' do
-    let(:request) { graphql query(dynamic_field_group.string_key) }
+    let(:request) { graphql query(dynamic_field_group.id) }
   end
 
   context 'when logged in user is an administrator' do
     before { sign_in_user as: :administrator }
 
     context 'when stringKey is valid' do
-      before { graphql query(dynamic_field_group.string_key) }
+      before { graphql query(dynamic_field_group.id) }
       it 'returns correct response' do
         expect(response.body).to be_json_eql(%({ "dynamicFieldGroup": { "parent": { "type": "DynamicFieldCategory" }, "children": [], "displayLabel": "Name",
                                                  "isRepeatable": true,  "sortOrder": 3, "stringKey": "name", "type": "DynamicFieldGroup", "exportRules": [] } }
           )).at_path('data')
       end
     end
-    context 'when stringKey is invalid' do
+    context 'when id is invalid' do
       before { graphql query('1234') }
 
       it 'returns correct response' do
         expect(response.body).to be_json_eql(%(
-           "Couldn't find DynamicFieldGroup"
+           "Couldn't find DynamicFieldGroup with 'id'=1234"
           )).at_path('errors/0/message')
       end
     end
   end
 
-  def query(string_key)
+  def query(id)
     <<~GQL
       query {
-        dynamicFieldGroup(stringKey: "#{string_key}") {
+        dynamicFieldGroup(id: "#{id}") {
           parent{
             type: __typename
           }

--- a/spec/requests/graphql/query/dynamic_field_spec.rb
+++ b/spec/requests/graphql/query/dynamic_field_spec.rb
@@ -6,12 +6,13 @@ RSpec.describe 'Retrieving Dynamic Field', type: :request do
   let(:dynamic_field) { FactoryBot.create(:dynamic_field) }
 
   include_examples 'requires user to have correct permissions for graphql request' do
-    let(:request) { graphql query(dynamic_field.string_key) }
+    let(:request) { graphql query(dynamic_field.id) }
   end
+
   context 'when logged in user is an administrator' do
     before { sign_in_user as: :administrator }
     context 'when stringKey is valid' do
-      before { graphql query(dynamic_field.string_key) }
+      before { graphql query(dynamic_field.id) }
       it 'returns correct response' do
         expect(response.body).to be_json_eql(%({  "dynamicField": { "controlledVocabulary": "name_role", "displayLabel": "Value",
           "fieldType": "controlled_term", "filterLabel": "Name", "isFacetable": true, "isIdentifierSearchable": false, "isKeywordSearchable": false,
@@ -20,19 +21,19 @@ RSpec.describe 'Retrieving Dynamic Field', type: :request do
       end
     end
 
-    context 'when stringKey is invalid' do
+    context 'when id is invalid' do
       before { graphql query('not-valid') }
       it 'returns correct response' do
         expect(response.body).to be_json_eql(%(
-           "Couldn't find DynamicField"
+           "Couldn't find DynamicField with 'id'=not-valid"
           )).at_path('errors/0/message')
       end
     end
   end
-  def query(string_key)
+  def query(id)
     <<~GQL
     query {
-      dynamicField(stringKey: "#{string_key}") {
+      dynamicField(id: "#{id}") {
         type: __typename
         id
         stringKey


### PR DESCRIPTION
I just realized that we can't use `string_key` as identifiers for dynamic field group and dynamic fields because `string_key`s for these two models aren't meant to be unique. The path for each field is unique. Therefore we can't use `string_keys` to do lookups.