### PR TITLE
Development environment reset task + updated reindex task

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -93,6 +93,7 @@ Metrics/BlockLength:
     - 'lib/hyacinth/adapters/external_identifier_adapter/datacite/metadata_builder.rb'
     - 'lib/tasks/hyacinth.rake'
     - 'lib/tasks/hyacinth/ci.rake'
+    - 'lib/tasks/hyacinth/development.rake'
     - 'lib/tasks/hyacinth/setup.rake'
     - 'lib/tasks/resque.rake'
 

--- a/lib/tasks/hyacinth.rake
+++ b/lib/tasks/hyacinth.rake
@@ -5,21 +5,22 @@ namespace :hyacinth do
     DigitalObjectRecord.find_in_batches(batch_size: (ENV['BATCH_SIZE'] || 1000).to_i) do |records|
       records.each do |record|
         ::DigitalObject::Base.find(record.uid).index(false)
-      rescue => e
+      rescue
         puts "Error while reindexing #{record.uid}. See raised error below:"
-        raise e
+        raise
       end
       Hyacinth::Config.digital_object_search_adapter.solr.commit
     end
   end
 
   task purge_all_digital_objects: :environment do
-    puts Rainbow("This will delete ALL digital objects in Rails.env #{Rails.env} and cannot be undone. Are you sure you want to do this? (yes/no)").red.bright
+    puts Rainbow("This will delete ALL digital objects in the selected Rails environment (#{Rails.env}) and cannot be undone. "\
+      "Please confirm that you want to continue by typing in the selected Rails environment (#{Rails.env}):").red.bright
     print '> '
-    response = ENV['yes'] || STDIN.gets.chomp
+    response = ENV['rails_env_confirmation'] || STDIN.gets.chomp
 
-    if response != 'yes'
-      puts 'Aborting because "yes" was not entered.'
+    if response != Rails.env
+      puts "Aborting because \"#{Rails.env}\" was not entered."
       next
     end
 

--- a/lib/tasks/hyacinth.rake
+++ b/lib/tasks/hyacinth.rake
@@ -4,12 +4,10 @@ namespace :hyacinth do
   task reindex: :environment do
     DigitalObjectRecord.find_in_batches(batch_size: (ENV['BATCH_SIZE'] || 1000).to_i) do |records|
       records.each do |record|
-        begin
-          ::DigitalObject::Base.find(record.uid).index(false)
-        rescue => e
-          puts "Error while reindexing #{record.uid}. See raised error below:"
-          raise e
-        end
+        ::DigitalObject::Base.find(record.uid).index(false)
+      rescue => e
+        puts "Error while reindexing #{record.uid}. See raised error below:"
+        raise e
       end
       Hyacinth::Config.digital_object_search_adapter.solr.commit
     end

--- a/lib/tasks/hyacinth.rake
+++ b/lib/tasks/hyacinth.rake
@@ -11,7 +11,7 @@ namespace :hyacinth do
   task purge_all_digital_objects: :environment do
     puts Rainbow("This will delete ALL digital objects in Rails.env #{Rails.env} and cannot be undone. Are you sure you want to do this? (yes/no)").red.bright
     print '> '
-    response = STDIN.gets.chomp
+    response = ENV['yes'] || STDIN.gets.chomp
 
     if response != 'yes'
       puts 'Aborting because "yes" was not entered.'
@@ -35,7 +35,7 @@ namespace :hyacinth do
           merge_rights: false
         )
         begin
-          dobj.purge!
+          dobj.purge!(skip_child_check: true)
           puts "Purged: #{record.uid}"
         rescue Hyacinth::Exceptions::NotFound
           puts "Purged #{record.uid} (but no associated metadata was found)"

--- a/lib/tasks/hyacinth.rake
+++ b/lib/tasks/hyacinth.rake
@@ -3,7 +3,14 @@
 namespace :hyacinth do
   task reindex: :environment do
     DigitalObjectRecord.find_in_batches(batch_size: (ENV['BATCH_SIZE'] || 1000).to_i) do |records|
-      records.each { |record| ::DigitalObject::Base.find(record.uid).index(false) }
+      records.each do |record|
+        begin
+          ::DigitalObject::Base.find(record.uid).index(false)
+        rescue => e
+          puts "Error while reindexing #{record.uid}. See raised error below:"
+          raise e
+        end
+      end
       Hyacinth::Config.digital_object_search_adapter.solr.commit
     end
   end

--- a/lib/tasks/hyacinth/development.rake
+++ b/lib/tasks/hyacinth/development.rake
@@ -10,7 +10,7 @@ namespace :hyacinth do
       end
 
       begin
-        Hyacinth::Config.digital_object_search_adapter.search({}).inspect
+        Hyacinth::Config.digital_object_search_adapter.search({})
       rescue Errno::ECONNREFUSED
         # Solr isn't running so we'll start it
         Rake::Task['solr:start'].invoke

--- a/lib/tasks/hyacinth/development.rake
+++ b/lib/tasks/hyacinth/development.rake
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+namespace :hyacinth do
+  namespace :development do
+    desc "Resets the development environment, clearing all data and setting up default objects."
+    task reset: :environment do
+      unless Rails.env.development?
+        puts 'This task can only be run in the development environment.'
+        next
+      end
+
+      begin
+        Hyacinth::Config.digital_object_search_adapter.search({}).inspect
+      rescue Errno::ECONNREFUSED
+        # Solr isn't running so we'll start it
+        Rake::Task['solr:start'].invoke
+      end
+
+      ENV['yes'] = 'yes' # allow automatic yes to prompt in purge task
+      Rake::Task['hyacinth:purge_all_digital_objects'].invoke
+      ENV.delete('yes') # done with this env variable
+
+      Rake::Task['db:environment:set'].invoke
+      Rake::Task['db:drop'].invoke
+      Rake::Task['db:create'].invoke
+      Rake::Task['db:migrate'].invoke
+
+      Rake::Task['hyacinth:setup:config_files'].invoke
+      Rake::Task['hyacinth:setup:default_users'].invoke
+      Rake::Task['hyacinth:setup:test_projects'].invoke
+      Rake::Task['hyacinth:setup:seed_dynamic_field_entries'].invoke
+    end
+  end
+end

--- a/lib/tasks/hyacinth/development.rake
+++ b/lib/tasks/hyacinth/development.rake
@@ -28,6 +28,7 @@ namespace :hyacinth do
       Rake::Task['hyacinth:setup:config_files'].invoke
       Rake::Task['hyacinth:setup:default_users'].invoke
       Rake::Task['hyacinth:setup:test_projects'].invoke
+      Rake::Task['hyacinth:rights_fields:load'].invoke
       Rake::Task['hyacinth:setup:seed_dynamic_field_entries'].invoke
     end
   end

--- a/lib/tasks/hyacinth/development.rake
+++ b/lib/tasks/hyacinth/development.rake
@@ -16,7 +16,7 @@ namespace :hyacinth do
         Rake::Task['solr:start'].invoke
       end
 
-      ENV['yes'] = 'yes' # allow automatic yes to prompt in purge task
+      ENV['rails_env_confirmation'] = 'development' # allow automatic prompt confirmation in purge task
       Rake::Task['hyacinth:purge_all_digital_objects'].invoke
       ENV.delete('yes') # done with this env variable
 


### PR DESCRIPTION
New development task (hyacinth:development:reset) clears all local data and sets up new basic setup data via hyacinth:setup:* tasks.

Also fixed purge_all_digital_objects task so that it no longer gets stuck on parent objects that have un-purged children.  Purge order doesn't matter when purging all objects.