### PR TITLE
Update to String Key Validation

### DIFF
--- a/app/validators/string_key_validator.rb
+++ b/app/validators/string_key_validator.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class StringKeyValidator < ActiveModel::EachValidator
-  ALPHANUMERIC_UNDERSCORE_KEY_REGEX = /\A[a-z]{1}[a-z0-9_]{0,240}\z/
-  MESSAGE = 'values must start with a letter, can only have up to 240 characters and can only contain lower case letters, numbers and underscores'
+  ALPHANUMERIC_UNDERSCORE_KEY_REGEX = /\A(?=.{1,240}$)[a-z]{1}[a-z0-9]*(?:_[a-z0-9]+)*\z/
+  MESSAGE = 'values must be up to 240 characters long, start with a lowercase letter, groupings ' \
+            'of lowercase letters and numbers can be seperated by ONE underscore'
 
   def validate_each(record, attribute, value)
     return if value.nil?

--- a/spec/models/dynamic_field_group_spec.rb
+++ b/spec/models/dynamic_field_group_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe DynamicFieldGroup, type: :model do
 
       it 'returns correct error' do
         dynamic_field_group.save
-        expect(dynamic_field_group.errors.full_messages).to include 'String key values must start with a letter, can only have up to 240 characters and can only contain lower case letters, numbers and underscores'
+        expect(dynamic_field_group.errors.full_messages).to include 'String key values must be up to 240 characters long, start with a lowercase letter, groupings of lowercase letters and numbers can be seperated by ONE underscore'
       end
     end
 

--- a/spec/models/vocabulary_spec.rb
+++ b/spec/models/vocabulary_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Vocabulary, type: :model do
         expect(vocabulary.save).to be false
         expect(
           vocabulary.errors.full_messages
-        ).to include 'String key values must start with a letter, can only have up to 240 characters and can only contain lower case letters, numbers and underscores'
+        ).to include 'String key values must be up to 240 characters long, start with a lowercase letter, groupings of lowercase letters and numbers can be seperated by ONE underscore'
       end
     end
 
@@ -22,7 +22,7 @@ RSpec.describe Vocabulary, type: :model do
         expect(vocabulary.save).to be false
         expect(
           vocabulary.errors.full_messages
-        ).to include 'String key values must start with a letter, can only have up to 240 characters and can only contain lower case letters, numbers and underscores'
+        ).to include 'String key values must be up to 240 characters long, start with a lowercase letter, groupings of lowercase letters and numbers can be seperated by ONE underscore'
       end
     end
 
@@ -33,7 +33,7 @@ RSpec.describe Vocabulary, type: :model do
         expect(vocabulary.save).to be false
         expect(
           vocabulary.errors.full_messages
-        ).to include 'String key values must start with a letter, can only have up to 240 characters and can only contain lower case letters, numbers and underscores'
+        ).to include 'String key values must be up to 240 characters long, start with a lowercase letter, groupings of lowercase letters and numbers can be seperated by ONE underscore'
       end
     end
 

--- a/spec/validators/string_key_validator_spec.rb
+++ b/spec/validators/string_key_validator_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+class StringKeyValidatable
+  include ActiveModel::Validations
+  attr_accessor :string_key
+
+  validates :string_key, string_key: true
+end
+
+RSpec.describe StringKeyValidator do
+  subject(:obj) { StringKeyValidatable.new }
+
+  context 'with invalid string key' do
+    ['1potter', 'harry__potter', 'harry_potter_', '_harry_potter'].each do |invalid_str|
+      it "returns invalid for string: #{invalid_str}" do
+        obj.string_key = invalid_str
+        expect(obj.valid?).to be false
+        expect(
+          obj.errors[:string_key]
+        ).to match_array('values must be up to 240 characters long, start with a lowercase letter, groupings of lowercase letters and numbers can be seperated by ONE underscore')
+      end
+    end
+  end
+
+  context 'with valid string key' do
+    it "returns valid" do
+      obj.string_key = 'harry_potter'
+      expect(obj.valid?).to be true
+    end
+  end
+end


### PR DESCRIPTION
String key validation now ensures that segments of letters and numbers are separated with one underscore. 

More details here: HYACINTH-614