### PR TITLE
verify that DynamicFieldGroup path collisions are rescued and correct…

### DIFF
--- a/app/models/concerns/dynamic_field_structure/string_key.rb
+++ b/app/models/concerns/dynamic_field_structure/string_key.rb
@@ -17,7 +17,12 @@ module DynamicFieldStructure
       # Validate that the string_key is unique between all siblings.
       def unique_string_key
         sibling_string_keys = siblings.map(&:string_key)
-        errors.add(:string_key, 'is already in use by a sibling field or field group') if sibling_string_keys.include?(string_key)
+        path_error if sibling_string_keys.include?(string_key)
+      end
+
+      def path_error
+        errors.add(:string_key, 'is already in use by a sibling field or field group')
+        return false
       end
   end
 end

--- a/app/models/dynamic_field_group.rb
+++ b/app/models/dynamic_field_group.rb
@@ -29,6 +29,11 @@ class DynamicFieldGroup < ActiveRecord::Base
   validate  :non_circular_relationship
   validates_with StringKey::AbsentInSiblingFieldsValidator
 
+  def save
+    super
+  rescue ActiveRecord::RecordNotUnique
+    path_error
+  end
   # Order children first by sort_order and then by string_key to break up ties.
   def ordered_children
     children.sort_by { |c| [c.sort_order, c.string_key] }

--- a/spec/models/dynamic_field_group_spec.rb
+++ b/spec/models/dynamic_field_group_spec.rb
@@ -166,6 +166,22 @@ RSpec.describe DynamicFieldGroup, type: :model do
       it 'saves the object' do
         expect(dynamic_field_group.save).to be true
       end
+
+      context 'and the sibiling is a dynamic_field_group, even across dynamic field categories', focus: true do
+        let(:parent1) { FactoryBot.create(:dynamic_field_category, display_label: 'DFC 1') }
+        let(:parent2) { FactoryBot.create(:dynamic_field_category, display_label: 'DFC 2') }
+        let(:dynamic_field_group) { FactoryBot.build(:dynamic_field_group, string_key: 'name', parent: parent1) }
+        before do
+          FactoryBot.create(:dynamic_field_group, string_key: 'name', parent: parent2)
+        end
+        it 'does not save' do
+          expect(dynamic_field_group.save).to be false
+        end
+        it 'returns correct error' do
+          dynamic_field_group.save
+          expect(dynamic_field_group.errors.full_messages).to include 'String key is already in use by a sibling field or field group'
+        end
+      end
     end
   end
 


### PR DESCRIPTION
…able (HYACINTH-568)

- rescue ActiveRecord::RecordNotUnique
- indicate in errors hash when DynamicFieldGroup path uniqueness is violated