### PR TITLE
Hyacinth 682 js error navigating parent child

### DIFF
--- a/app/javascript/hyacinth_v1/components/digital_objects/DigitalObjectInterface.js
+++ b/app/javascript/hyacinth_v1/components/digital_objects/DigitalObjectInterface.js
@@ -15,7 +15,6 @@ import { getDigitalObjectIDsQuery } from '../../graphql/digitalObjects';
 import { queryParamsConfig, encodeAndStringifySearch } from '../../utils/encodeAndStringifySearch';
 import GraphQLErrors from '../shared/GraphQLErrors';
 
-
 function DigitalObjectInterface(props) {
   const { digitalObject, children } = props;
   const { id, title, digitalObjectType } = digitalObject;
@@ -37,7 +36,7 @@ function DigitalObjectInterface(props) {
   const {
     q, filters, orderBy,
   } = decodeQueryParams(queryParamsConfig, queryParams);
-  
+
   const [orderField, orderDirection] = orderBy.split(' ');
 
   const searchParams = { query: q, filters };
@@ -133,16 +132,17 @@ function DigitalObjectInterface(props) {
       </TabBody>
       {
         // only show results paging if we came from a search and if there is more than one result
-      (uids.length > 1 && latestSearchQueryString != null) ? (
-        <ResultsPagingBar
-          totalCount={Number(totalCount)}
-          offset={Number(offset)}
-          uids={uids}
-          uidCurrent={id}
-          resultIndex={Number(resultIndex)}
-          onResultClick={onResultClick}
-        />
-      ) : <></>
+        // and if the current object was in the search result set
+        (uids.length > 1 && latestSearchQueryString != null && uids.includes(id)) ? (
+          <ResultsPagingBar
+            totalCount={Number(totalCount)}
+            offset={Number(offset)}
+            uids={uids}
+            uidCurrent={id}
+            resultIndex={Number(resultIndex)}
+            onResultClick={onResultClick}
+          />
+        ) : <></>
 }
     </div>
   );

--- a/app/javascript/hyacinth_v1/components/digital_objects/DigitalObjectInterface.js
+++ b/app/javascript/hyacinth_v1/components/digital_objects/DigitalObjectInterface.js
@@ -33,6 +33,9 @@ function DigitalObjectInterface(props) {
     ...JSON.parse(latestSearchQueryString),
   };
 
+  // reformat filters values for filterArrayParams encode parsing
+  queryParams.filters = queryParams.filters.map(filter => `${filter.field}::${filter.values}`);
+
   const {
     q, filters, orderBy,
   } = decodeQueryParams(queryParamsConfig, queryParams);

--- a/app/javascript/hyacinth_v1/components/digital_objects/DigitalObjectList.js
+++ b/app/javascript/hyacinth_v1/components/digital_objects/DigitalObjectList.js
@@ -54,7 +54,7 @@ const DigitalObjectList = (props) => {
             <Card.Header>
               <LinkContainer
                 to={`/digital_objects/${digitalObject.id}`}
-                onClick={() => storeSearchValues(
+                onClick={() => searchParams && storeSearchValues(
                   orderBy, totalCount, limit, offset,
                   pageNumber, searchParams.query, searchParams.filters, path, resultIndex,
                 )
@@ -112,7 +112,7 @@ DigitalObjectList.defaultProps = {
   limit: 0,
   offset: 0,
   pageNumber: 0,
-  searchParams: false,
+  searchParams: null,
   path: '',
 };
 


### PR DESCRIPTION
2 related fixes here: a filter param formatting issue that triggered the ticketed JS error, and a change that suppresses search result paging in the digital object show footer when not applicable.