### PR TITLE
preservation_target_uris is an assignable attribute (HYACINTH-603)

### DIFF
--- a/app/models/concerns/digital_object_concerns/attribute_assignment.rb
+++ b/app/models/concerns/digital_object_concerns/attribute_assignment.rb
@@ -43,6 +43,7 @@ module DigitalObjectConcerns
       assign_optimistic_lock_token(new_digital_object_data)
       assign_parents(new_digital_object_data)
       assign_preserve(new_digital_object_data)
+      assign_preservation_target_uris(new_digital_object_data)
       assign_pending_publish_entries(new_digital_object_data)
       assign_resource_imports(new_digital_object_data)
       assign_state(new_digital_object_data)

--- a/app/models/concerns/digital_object_concerns/attribute_assignment/preserve.rb
+++ b/app/models/concerns/digital_object_concerns/attribute_assignment/preserve.rb
@@ -9,6 +9,14 @@ module DigitalObjectConcerns
         return unless digital_object_data.key?('preserve')
         @preserve = digital_object_data['preserve'].to_s.casecmp('true').zero?
       end
+
+      def assign_preservation_target_uris(digital_object_data)
+        return unless digital_object_data.key?('preservation_target_uris')
+        preservation_target_uri_values = digital_object_data['preservation_target_uris'].to_set
+        return if preservation_target_uri_values == preservation_target_uris # no-op if same as current uris
+        raise Hyacinth::Exceptions::AlreadySet, "Cannot set preservation_target_uris because preservation_target_uris have already been set." if preservation_target_uris.present?
+        self.preservation_target_uris.merge(preservation_target_uri_values)
+      end
     end
   end
 end

--- a/spec/models/concerns/digital_object_concerns/attribute_assignment/preserve_spec.rb
+++ b/spec/models/concerns/digital_object_concerns/attribute_assignment/preserve_spec.rb
@@ -3,7 +3,45 @@
 require 'rails_helper'
 
 RSpec.describe DigitalObjectConcerns::AttributeAssignment::Preserve do
-  context "todo" do
-    skip 'todo'
+  let(:digital_object) { FactoryBot.build(:digital_object_test_subclass) }
+  let(:preservation_target_uris) { ['preservation:target/uri'] }
+  let(:digital_object_data_with_target_uris) do
+    {
+      'preservation_target_uris' => preservation_target_uris
+    }
+  end
+  let(:digital_object_data_with_different_target_uris) do
+    {
+      'preservation_target_uris' => ['preservation:different/uri']
+    }
+  end
+  let(:digital_object_with_target_uris) do
+    dobj = FactoryBot.build(:digital_object_test_subclass)
+    dobj.assign_preservation_target_uris(digital_object_data_with_target_uris)
+    dobj
+  end
+
+  context "#assign_preservation_target_uris" do
+    context "when no preservation target uris have been set" do
+      it "sets the preservation target uris" do
+        digital_object.assign_preservation_target_uris(digital_object_data_with_target_uris)
+        expect(digital_object.preservation_target_uris.to_a).to eq(preservation_target_uris)
+      end
+    end
+
+    context "when preservation target uris have already been set" do
+      it "raises an error if a different value is supplied" do
+        expect { digital_object_with_target_uris.assign_preservation_target_uris(digital_object_data_with_different_target_uris) }.to raise_error(Hyacinth::Exceptions::AlreadySet)
+      end
+
+      it "does not raise an error if the existing value is supplied" do
+        expect { digital_object_with_target_uris.assign_preservation_target_uris(digital_object_data_with_target_uris) }.not_to raise_error
+      end
+
+      it "does not clear the preservation target uris when digital object data with no preservation_target_uris key is supplied" do
+        digital_object_with_target_uris.assign_preservation_target_uris({})
+        expect(digital_object_with_target_uris.preservation_target_uris.to_a).to eq(preservation_target_uris)
+      end
+    end
   end
 end


### PR DESCRIPTION
This change allows preservation_target_uris to be set as an attribute if they were previously unassigned, or ignored if they are identical. It raises AlreadySet if the new value and an existing non-empty value do not match.
 