### PR TITLE
proposal for optional configurable loggers under Hyacinth::Adapters

### DIFF
--- a/config/templates/datacite.template.yml
+++ b/config/templates/datacite.template.yml
@@ -1,6 +1,10 @@
 default: &default
+  rest_api: 'https://api.test.datacite.org'
   user: apitest
   password: apitest
+  prefix: '10.33555'
+  log_api: false
+  log_level: warn
   shoulder:
     ark: 'ark:99999/fk4'
     doi: 'doi:10.5072/FK2'

--- a/config/templates/datacite.template.yml
+++ b/config/templates/datacite.template.yml
@@ -20,6 +20,9 @@ default: &default
       'http://vocab.getty.edu/aat/300048715':
         attribute_general: Text
         content: Article
+  logger:
+    log_level: debug
+    dev: 'datacite.log'
 development:
   <<: *default
 test:

--- a/docs/datacite.README.md
+++ b/docs/datacite.README.md
@@ -1,0 +1,121 @@
+# DataCite DOI implementation
+
+## DataCite Documentation and References
+
+- DataCite Rest API Guide: https://support.datacite.org/docs/api
+- DataCite REST API Reference: https://support.datacite.org/reference/introduction
+- DataCite Metadata Schema 4.4: https://schema.datacite.org/meta/kernel-4.4/
+
+## DataCite background info
+
+### DOI states, EZID vs DataCite
+
+- reserved (EZID) <==> draft (DataCite)
+- public (EZID) <==> findable (DataCite)
+- unavailable (EZID) <==> registered (DataCite)
+
+### Required DataCite Properties
+
+DataCite requires the following properties for a DOI in the findable state (including minting a findable DOI)
+
+- creators
+- publisher
+- publication year
+- resource type general (controlled?)
+- title
+- url
+
+## Introduction to the overall implementation of DataCite DOIs in Hyacinth
+
+There are three main classes in this implementation
+
+- Datacite::RestApi::V2::Api
+This class is the direct interface to the DataCite REST API. It includes three methods, one each for the GET, POST, and PUT requests that can
+be sent to the DataCite REST API. If included/relevant, the request body is given as an argument in JSON format.
+- Datacite::RestApi::V2::Data
+This class is used to populate and construct the JSON structure that will be sent via a request body to the DataCite REST API (see above)
+- Datacite
+This is the class that is used by the rest of Hyacinth to mint and update DOIs. It makes use of the above two classes. This class also contains
+the mapping functionality between Hyacinth fields and DataCite properties.
+
+There is also a legacy class, Datacite::Metadata
+This class wraps the Digital Object Data from a DigitalObject and provides methods to access metadata.
+NOTE: this class SHOULD move out of the datacite subdir since it is independent of the datacite functionality. Also, I would prefer to
+rename it HyacinthMetadata. Finally, this class should be preferred over a Digital Object as an argument to doi-related methods that need
+access to the metadata within a Digital Object since it offers a standardized interface to the metadata.
+
+## Running implementation in rails console using higher-level functionality
+
+### Using Datacite#mint_doi to mint a draft DOI
+
+This is the same method that will be used in the client code in Hyacinth to mint a DOI
+
+```
+2.6.4 :001 > dc = Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite.new
+ => #<Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite:0x000055f03ff47510>
+2.6.4 :002 > doi = dc.mint_doi
+ => "10.33555/qg65-ty77"
+2.6.4 :003 > puts doi
+10.33555/qg65-ty77
+ => nil
+ ```
+
+## Running implementation in rails console using lower-level functionality
+
+The functionality used here is supplied by lower-level classes that are normally not called by client code. However, they offer
+more granular functionality which may be useful when debugging
+
+### get info for a given DOI (GET)
+
+```
+2.6.4 :001 > conf.return_format = "" # supress output for clarity
+2.6.4 :002 > api =  Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::RestApi::V2::Api.new('https://api.test.datacite.org','USERNAME','PASSWORD')
+2.6.4 :003 > resp = api.get_dois('10.33555/9fa4-xx07')
+2.6.4 :004 > puts resp.body
+{"data":{"id":"10.33555/9fa4-xx07","type":"dois","attributes":{"doi":"10.33555/9fa4-xx07","prefix":"10.33555","suffix":"9fa4-xx07", --REST REMOVED for BREVITY---
+```
+
+### mint a reserved DOI (POST)
+
+```
+2.6.4 :001 > conf.return_format = "" # supress output for clarity
+2.6.4 :002 > api =  Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::RestApi::V2::Api.new
+2.6.4 :003 > resp = api.post_dois('{"data":{"type":"dois","attributes":{"prefix":"10.33555"}}}')
+```
+
+Note that if no arguments are given when instantiating the Api instance, the information in the datacite config file will be used
+Note that in the example above, we passed in the payload content as json. In the example below, we will use a Data instance:
+
+```
+2.6.4 :001 > conf.return_format = "" # supress output for clarity
+2.6.4 :002 > api =  Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::RestApi::V2::Api.new('https://api.test.datacite.org','USERNAME','PASSWORD')
+2.6.4 :003 > data = Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::RestApi::V2::Data.new('10.33555')
+2.6.4 :004 > data.build_mint(:draft)
+2.6.4 :005 > resp = api.post_dois(data.generate_json_payload)
+2.6.4 :008 > puts api.parse_doi_from_api_response_body(resp.body)
+10.33555/6zy2-pw34
+2.6.4 :009 >
+```
+
+The Api class supplies methods to parse out relevant information from the response, as can be seen above.
+
+### Update an existing DOI (PUT)
+
+```
+2.6.4 :001 > conf.return_format = "" # supress output for clarity
+2.6.4 :002 > api =  Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::RestApi::V2::Api.new('https://api.test.datacite.org','USERNAME','PASSWORD')
+2.6.4 :003 > data = Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::RestApi::V2::Data.new
+2.6.4 :004 > data.creators = ['Mouse, Katie', 'Mouse, John']
+2.6.4 :005 > data.publisher = 'Columbia University'
+2.6.4 :006 > data.publication_year = 2021
+2.6.4 :007 > data.resource_type_general = 'Text'
+2.6.4 :008 > data.title = "A Great Book"
+2.6.4 :009 > data.url = "https://www.columbia.edu"
+2.6.4 :010 > data.build_metadata_update
+2.6.4 :012 > resp = api.put_dois('10.33555/6zy2-pw34', data.generate_json_payload)
+2.6.4 :013 > puts resp.body
+{"data":{"id":"10.33555/6zy2-pw34","type":"dois","attributes":{"doi":"10.33555/6zy2-pw34","prefix":"10.33555","suffix":"6zy2-pw34","identifiers":[],"alternateIdentifiers":[],"creators":[{"name":"Mouse, Katie","affiliation":[],"nameIdentifiers":[]},{"name":"Mouse, John","affiliation":[],"nameIdentifiers":[]}],"titles":[{"title":"A Great Book"} ETC...
+```
+
+As seen in the example above, if the prefix is not passed when the Data is instantiated (as it was in the previous example), it will get it from the config file.
+

--- a/lib/hyacinth/adapters/configurable_logger.rb
+++ b/lib/hyacinth/adapters/configurable_logger.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Hyacinth
+  module Adapters
+    module ConfigurableLogger
+      extend ActiveSupport::Concern
+      included do
+        attr_accessor :logger
+      end
+
+      def configure_logger(config)
+        @logger = configured_logger(config)
+      end
+
+      def configured_logger(config = {})
+        if config[:logger].present?
+          logdev = config.dig(:logger, :dev) || Rails.logger.instance_variable_get(:@logdev)
+          logdev = Rails.root.join('log', logdev) if logdev.is_a? String
+          level = config.dig(:logger, :log_level)&.to_sym || Rails.logger.instance_variable_get(:@level)
+          ActiveSupport::Logger.new(logdev, level: level)
+        else
+          Rails.logger
+        end
+      end
+    end
+  end
+end

--- a/lib/hyacinth/adapters/external_identifier_adapter/README.md
+++ b/lib/hyacinth/adapters/external_identifier_adapter/README.md
@@ -1,0 +1,2 @@
+For datacite subsystem info, please see docs/datacite.README.md
+

--- a/lib/hyacinth/adapters/external_identifier_adapter/datacite.rb
+++ b/lib/hyacinth/adapters/external_identifier_adapter/datacite.rb
@@ -4,109 +4,136 @@ module Hyacinth
   module Adapters
     module ExternalIdentifierAdapter
       class Datacite < Abstract
-        IDENTIFIER_STATUS = { public: 'public',
-                              reserved: 'reserved',
-                              unavailable: 'unavailable' }.freeze
+        DOI_STATES = [:draft, :findable, :registered].freeze
+
+        # https://schema.datacite.org/meta/kernel-4.4/doc/DataCite-MetadataKernel_v4.4.pdf
+        REQUIRED_DATACITE_METADATA_PROPERTIES = [:creators,
+                                                 :publisher,
+                                                 :publication_year,
+                                                 :resource_type_general,
+                                                 :title,
+                                                 :url].freeze
+
+        # https://schema.datacite.org/meta/kernel-4.4/doc/DataCite-MetadataKernel_v4.4.pdf
+        SUPPORTED_DATACITE_METADATA_PROPERTIES = [:subject,
+                                                  :stuff].concat(REQUIRED_DATACITE_METADATA_PROPERTIES).freeze
+        attr_reader :rest_api
+
         def initialize(adapter_config = {})
           super(adapter_config)
         end
 
         # @param id [String]
-        # @return [Boolean] true if this adapter can handle this type of identifier
+        # @return [Boolean] true if this adapteppr can handle this type of identifier
         def handles?(id)
           id =~ /^10\.[A-Za-z0-9]+\/[A-Za-z0-9\-]+/
         end
 
-        # Generates a new persistent id, ensuring that nothing currently uses that identifier.
-        # @return [String] a new id
-        def mint
-          # metadata is blank when minting
-          # TODO: allow existing object data to be pushed on mint
-          metadata = {}
-          # target is blank when minting
-          # TODO: allow existing object data to be pushed on mint
-          target_url = nil
-          # status is reserved when minting
-          # TODO: allow provided target
-          identifier_status = IDENTIFIER_STATUS[:reserved]
-          # mint_identifier returns a Hyacinth::Ezid::Doi
-          ezid_doi_instance = api_session.mint_identifier(DATACITE[:shoulder][:doi], identifier_status, target_url, metadata)
-          # if above method returned nil, call to EZID API was unsuccessful. Return nil to indicate failure
-          # if unsuccessful because of timeout, log faiilure and return nil
-          if api_session.timed_out?
-            log(:error, "#mint_and_store_doi: EZID API call to mint_identifier timed-out.")
-            return nil
+        # metadata is not required when minting a draft DOI.
+        # metadata is required when minting a findable DOI. This metadata must include all the
+        # properties required by DataCite.
+        # It is also possible to specify a (non-existent) DOI when minting. However, this is not
+        # currently supported in the code.
+        def mint(hyacinth_metadata = nil, # Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::Metadata
+                 target_url = nil, doi_state = :draft, _doi = nil)
+          if doi_state != :draft && hyacinth_metadata.nil?
+            Rails.logger.error "Hyacinth metadata required to mint DOI in #{doi_state} state"
+            return
           end
-          # if got a response from EZID server indicating failure, log info and return nil
-          if ezid_doi_instance.nil?
-            response = api_session.last_response_from_server
-            log(:error, "#mint_and_store_doi: EZID API call to mint_identifier was unsuccessful.")
-            log(:error, "#mint_and_store_doi: Response from EZID server follows:\n#{http_error_message(response)}")
-            return nil
+          datacite_data = Datacite::RestApi::V2::Data.new
+          datacite_data.prefix = DATACITE[:prefix]
+          map_metadata(hyacinth_metadata, datacite_data, target_url) if hyacinth_metadata
+          datacite_data.build_mint(doi_state, hyacinth_metadata.present?)
+          rest_api = Datacite::RestApi::V2::Api.new(DATACITE[:rest_api], DATACITE[:user], DATACITE[:password])
+          rest_api_response = rest_api.post_dois datacite_data.generate_json_payload
+          unless rest_api_response.status.eql? 201
+            Rails.logger.error "Did not mint a DOI! Response Code: #{rest_api_response.status}." \
+                               "Response Body: #{rest_api_response.body}." \
+                               "Request Body: #{rest_api.most_recent_request_body}"
+            return
           end
-          ezid_doi_instance.identifier.sub(/^doi\:/, '')
+          rest_api.parse_doi_from_api_response_body(rest_api_response.body)
+        end
+
+        # return nil if unsuccessful, else returns the response body
+        def update_doi(doi,
+                       hyacinth_metadata, # Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::Metadata
+                       target_url, doi_state = nil)
+          datacite_data = Datacite::RestApi::V2::Data.new
+          datacite_data.prefix = DATACITE[:prefix]
+          map_metadata(hyacinth_metadata, datacite_data, target_url)
+          datacite_data.build_properties_update(doi_state)
+          rest_api = Datacite::RestApi::V2::Api.new(DATACITE[:rest_api], DATACITE[:user], DATACITE[:password])
+          rest_api_response = rest_api.put_dois(doi, datacite_data.generate_json_payload)
+          unless rest_api_response.status.eql? 200
+            Rails.logger.error "Did not update a DOI! Response Code: #{rest_api_response.status}." \
+                               "Response Body: #{rest_api_response.body}." \
+                               "Request Body: #{rest_api.most_recent_request_body}"
+            return
+          end
+          rest_api_response.body
+        end
+
+        # Following only updates the target url. Assumes the other required DataCite properties
+        # are already set. If not sure, use update_doi(doi, hyacinth_metadata, target_url, doi_state = nil)
+        # and supply required metadata
+        # return nil if unsuccessful, else returns the response body
+        def update_doi_target_url(doi, target_url)
+          datacite_data = Datacite::RestApi::V2::Data.new
+          datacite_data.prefix = DATACITE[:prefix]
+          datacite_data.url = target_url
+          datacite_data.build_properties_update
+          rest_api = Datacite::RestApi::V2::Api.new(DATACITE[:rest_api], DATACITE[:user], DATACITE[:password])
+          rest_api_response = rest_api.put_dois(doi, datacite_data.generate_json_payload)
+          unless rest_api_response.status.eql? 200
+            Rails.logger.error "Did not mint a DOI! Response Code: #{rest_api_response.status}." \
+                               "Response Body: #{rest_api_response.body}." \
+                               "Request Body: #{rest_api.most_recent_request_body}"
+            return
+          end
+          rest_api_response.body
+        end
+
+        def map_metadata(hyacinth_metadata, datacite_data, target_url)
+          return unless hyacinth_metadata
+          # BEGIN metadata required by DataCite
+          # Of course, we can come up with other/better default values
+          datacite_data.title = hyacinth_metadata.title || 'Placeholder Title'
+          datacite_data.creators = hyacinth_metadata.creators || 'Placeholder Creator'
+          map_publication_metadata(hyacinth_metadata, datacite_data)
+          datacite_data.resource_type_general = hyacinth_metadata.type_of_resource || "Text"
+          datacite_data.url = target_url || 'https://library.columbia.edu'
+          # END metadata required by DataCite
+        end
+
+        def map_publication_metadata(hyacinth_metadata, datacite_data)
+          datacite_data.publisher = hyacinth_metadata.publisher || "Placeholder Publisher"
+          datacite_data.publication_year = hyacinth_metadata.date_issued_start_year.to_i ||
+                                           "Placeholder Publication Year"
         end
 
         # Returns true if an identifier exists in the external management system
-        def exists?(_id)
-          raise NotImplementedError
+        def exists?(doi)
+          rest_api = Datacite::RestApi::V2::Api.new(DATACITE[:rest_api], DATACITE[:user], DATACITE[:password])
+          resp = rest_api.get_dois(doi)
+          rest_api.parse_doi_from_api_response_body(resp.body).present?
         end
 
         # @param id [String]
         # @param digital_object [DigitalObject]
         # @param location_uri [String]
         # @return [Boolean] true if this adapter can handle this type of identifier
-        def update_impl(id, digital_object, location_uri)
-          return update_doi_target_url(id, location_uri) if digital_object.blank?
-
-          # get the metadata from hyacinth
-          hyacinth_metadata = Datacite::Metadata.new digital_object.as_json
-          # prepare the metadata into an acceptable format for EZID
-          datacite_metadata = Datacite::MetadataBuilder.new hyacinth_metadata
-          # ApiSession#modify_identifier returns true if the response from the EZID server indicated
-          # success, else it returns false
-          opts = { datacite: datacite_metadata.datacite_xml, _status: IDENTIFIER_STATUS[:public] }
-          opts[:_target] = location_uri unless location_uri.blank?
-          api_session.modify_identifier(id, opts)
+        def update_impl(_id, _digital_object, _location_uri)
+          # needs state as a parameter in order to be able to update DOI state
+          # also, prefer a Metadata as an argument instead of a Digital Object. Metadata offers "accessors" to
+          # get to metadata inside Digital Object
+          raise NotImplementedError
         end
 
-        # Following method will make a request to the EZID server to update the target URL associated
-        # with the EZID DOI entry on the server.
-        # (See _target in http://ezid.cdlib.org/doc/apidoc.html#internal-metadata)
-        # To delete the target URL stored in the DOI server, use an empty string as the argument.
-        # Uses the modify identifier API call, returns true if metadata update was successful
-        # if not, returns false
-        def update_doi_target_url(doi, target_url)
-          return false if doi.nil?
-          return false if target_url.nil?
-          # ApiSession#modify_identifier returns true if the response from the EZID server indicated
-          # success, else it returns false
-          api_session.modify_identifier(doi, _target: target_url, _status: IDENTIFIER_STATUS[:public])
+        def tombstone_impl(_id)
+          # switch state to registered?
+          raise NotImplementedError
         end
-
-        def tombstone_impl(id)
-          return false if id.nil?
-          # ApiSession#modify_identifier returns true if the response from the EZID server indicated
-          # success, else it returns false
-          api_session.modify_identifier(id, _status: IDENTIFIER_STATUS[:unavailable])
-        end
-
-        private
-
-          # setup EZID API info: credentials, url, etc.
-          def api_session
-            Thread.current[:datacite_ezid_api_session] ||= Datacite::EzidSession.new(DATACITE[:user], DATACITE[:password])
-          end
-
-          def http_error_message(response)
-            return "" if response.nil?
-            "HTTP status code: #{response.http_status_code}\n" \
-            "HTTP server message: #{response.http_server_message}\n" \
-            "response body: #{response.body}"
-          end
-
-          # TODO: Remove this method when there's a general logging proxy
-          def log(status, message); end
       end
     end
   end

--- a/lib/hyacinth/adapters/external_identifier_adapter/datacite/metadata.rb
+++ b/lib/hyacinth/adapters/external_identifier_adapter/datacite/metadata.rb
@@ -65,6 +65,14 @@ class Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::Metadata
     @descriptive_metadata.dig('abstract', 0, 'value')
   end
 
+  # the abstract of an item
+  # @api public
+  # @return [String, nil]
+  # @note only returns the first abstract value
+  def publisher
+    @descriptive_metadata.dig('publisher', 0, 'value')
+  end
+
   # the type of resource for an item
   # @api public
   # @return [String, nil]
@@ -122,13 +130,6 @@ class Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::Metadata
   # @return [String, nil]
   def parent_publication_doi
     @descriptive_metadata.dig('parent_publication', 0, 'doi')
-  end
-
-  # handle indentifier value
-  # @api public
-  # @return [String, nil]
-  def handle_net_identifier
-    @descriptive_metadata.dig('cnri_handle_identifier', 0, 'value')
   end
 
   # retrieve subject topics from [@descriptive_metadata]

--- a/lib/hyacinth/adapters/external_identifier_adapter/datacite/rest_api/v2/api.rb
+++ b/lib/hyacinth/adapters/external_identifier_adapter/datacite/rest_api/v2/api.rb
@@ -15,6 +15,8 @@ class Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::RestApi::V2::Api
                      findable: 'publish',
                      registered: 'hide' }.freeze
 
+  include Hyacinth::Adapters::ConfigurableLogger
+
   attr_accessor :most_recent_request_body,
                 :most_recent_response
 
@@ -24,6 +26,7 @@ class Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::RestApi::V2::Api
     @datacite_rest_api_url = datacite_rest_api_url
     @basic_auth_user = basic_auth_user
     @basic_auth_password = basic_auth_password
+    @logger = configured_logger(DATACITE)
   end
 
   # see https://support.datacite.org/reference/dois-2#get_dois-id
@@ -32,13 +35,8 @@ class Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::RestApi::V2::Api
     conn = Faraday.new(@datacite_rest_api_url)
     conn.basic_auth(@basic_auth_user, @basic_auth_password)
     response = conn.get("/dois/#{doi}")
-    log("API response body: #{response.body}", DATACITE[:log_level]) if DATACITE[:log_api]
+    logger.debug("API response body: #{response.body}")
     response
-  end
-
-  def log(log_msg, log_level)
-    return if ['debug', 'info', 'warn', 'error', 'fatal', 'unknown'].exclude? log_level
-    Rails.logger.public_send(log_level, log_msg)
   end
 
   def parse_doi_from_api_response_body(api_http_response_body)
@@ -63,7 +61,7 @@ class Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::RestApi::V2::Api
       req.headers['Content-Type'] = 'application/vnd.api+json'
       req.body = request_body_json
     end
-    log("API response body: #{response.body}", DATACITE[:log_level]) if DATACITE[:log_api]
+    logger.debug("API response body: #{response.body}")
     response
   end
 
@@ -76,7 +74,7 @@ class Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::RestApi::V2::Api
       req.headers['Content-Type'] = 'application/vnd.api+json'
       req.body = request_body_json
     end
-    log("API response body: #{response.body}", DATACITE[:log_level]) if DATACITE[:log_api]
+    logger.debug("API response body: #{response.body}")
     response
   end
 end

--- a/lib/hyacinth/adapters/external_identifier_adapter/datacite/rest_api/v2/api.rb
+++ b/lib/hyacinth/adapters/external_identifier_adapter/datacite/rest_api/v2/api.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+require 'json'
+class Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::RestApi::V2::Api
+  MINIMUM_REQUIRED_ATTRIBUTES_FOR_FINDABLE_DOI = [:title,
+                                                  :creators,
+                                                  :doi_url,
+                                                  :publisher,
+                                                  :publication_year,
+                                                  :resource_type,
+                                                  :doi_prefix].freeze
+  # Events used when minting a DOI, depends on desired state of minted DOI
+  # see https://support.datacite.org/docs/how-do-i-make-a-findable-doi-with-the-rest-api
+  DOI_STATES = [:draft, :findable, :registered].freeze
+  DOI_MINT_EVENT = { draft: '',
+                     findable: 'publish',
+                     registered: 'hide' }.freeze
+
+  attr_accessor :most_recent_request_body,
+                :most_recent_response
+
+  def initialize(datacite_rest_api_url = DATACITE[:rest_api],
+                 basic_auth_user = DATACITE[:user],
+                 basic_auth_password = DATACITE[:password])
+    @datacite_rest_api_url = datacite_rest_api_url
+    @basic_auth_user = basic_auth_user
+    @basic_auth_password = basic_auth_password
+  end
+
+  # see https://support.datacite.org/reference/dois-2#get_dois-id
+  # 'Returns a doi.'
+  def get_dois(doi)
+    conn = Faraday.new(@datacite_rest_api_url)
+    conn.basic_auth(@basic_auth_user, @basic_auth_password)
+    response = conn.get("/dois/#{doi}")
+    log("API response body: #{response.body}", DATACITE[:log_level]) if DATACITE[:log_api]
+    response
+  end
+
+  def log(log_msg, log_level)
+    return if ['debug', 'info', 'warn', 'error', 'fatal', 'unknown'].exclude? log_level
+    Rails.logger.public_send(log_level, log_msg)
+  end
+
+  def parse_doi_from_api_response_body(api_http_response_body)
+    JSON.parse(api_http_response_body).dig('data', 'attributes', 'doi')
+  end
+
+  def parse_state_from_api_response_body(api_http_response_body)
+    JSON.parse(api_http_response_body).dig('data', 'attributes', 'state')
+  end
+
+  def parse_url_from_api_response_body(api_http_response_body)
+    JSON.parse(api_http_response_body).dig('data', 'attributes', 'url')
+  end
+
+  # see https://support.datacite.org/reference/dois-2#post_dois
+  # 'Add a new doi.'
+  # In other words, used to mint DOIs
+  def post_dois(request_body_json)
+    conn = Faraday.new(@datacite_rest_api_url)
+    conn.basic_auth(@basic_auth_user, @basic_auth_password)
+    response = conn.post("/dois") do |req|
+      req.headers['Content-Type'] = 'application/vnd.api+json'
+      req.body = request_body_json
+    end
+    log("API response body: #{response.body}", DATACITE[:log_level]) if DATACITE[:log_api]
+    response
+  end
+
+  # see https://support.datacite.org/reference/dois-2#put_dois-id
+  # 'Update a doi.'
+  def put_dois(doi, request_body_json)
+    conn = Faraday.new(@datacite_rest_api_url)
+    conn.basic_auth(@basic_auth_user, @basic_auth_password)
+    response = conn.put("/dois/#{doi}") do |req|
+      req.headers['Content-Type'] = 'application/vnd.api+json'
+      req.body = request_body_json
+    end
+    log("API response body: #{response.body}", DATACITE[:log_level]) if DATACITE[:log_api]
+    response
+  end
+end

--- a/lib/hyacinth/adapters/external_identifier_adapter/datacite/rest_api/v2/data.rb
+++ b/lib/hyacinth/adapters/external_identifier_adapter/datacite/rest_api/v2/data.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+require 'json'
+class Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::RestApi::V2::Data
+  MINIMUM_REQUIRED_ATTRIBUTES_FOR_FINDABLE_DOI = [:title,
+                                                  :creators,
+                                                  :doi_url,
+                                                  :publisher,
+                                                  :publication_year,
+                                                  :resource_type,
+                                                  :doi_prefix].freeze
+  # Events used when minting a DOI, depends on desired state of minted DOI
+  # see https://support.datacite.org/docs/how-do-i-make-a-findable-doi-with-the-rest-api
+  DOI_STATES = [:draft, :findable, :registered].freeze
+  DOI_MINT_EVENT = { draft: '',
+                     findable: 'publish',
+                     registered: 'hide' }.freeze
+
+  attr_accessor :attributes,
+                :data_hash,
+                :creators,
+                :publisher,
+                :publication_year,
+                :resource_type_general, # controlled, usually "Text"
+                :title,
+                :url
+
+  attr_accessor :prefix
+
+  def initialize(prefix = DATACITE[:prefix])
+    @attributes = { prefix: prefix }
+    @data_hash = {}
+    @data_hash[:type] = 'dois'
+    @data_hash[:attributes] = @attributes
+    @creators = []
+  end
+
+  def add_properties_to_attributes_hash
+    unless @creators.empty?
+      @attributes[:creators] = []
+      @creators.each { |creator| @attributes[:creators].push(name: creator) }
+    end
+    @attributes[:titles] = [{ title: @title }] if @title
+    @attributes[:publisher] = @publisher
+    @attributes[:publicationYear] = @publication_year
+    @attributes[:types] = { resourceTypeGeneral: @resource_type_general } if @resource_type_general
+    @attributes[:url] = @url
+    @attributes[:schemaVersion] = 'http://datacite.org/schema/kernel-4'
+    @attributes.compact!
+  end
+
+  def build_mint(doi_state = :draft, with_metadata = false)
+    case doi_state
+    when :draft
+      add_properties_to_attributes_hash if with_metadata
+    when :findable, :registered
+      raise "Need metadata to mint a #{doi_state} DOI" unless with_metadata
+      add_properties_to_attributes_hash
+    end
+    # add event, which triggers DOI state change on DataCite server
+    add_event(doi_state)
+  end
+
+  def build_properties_update(doi_state = nil)
+    add_properties_to_attributes_hash
+    # add event, which triggers DOI state change on DataCite server
+    add_event(doi_state) if doi_state
+  end
+
+  # from testing on the DataCite test API, only the following info is required:
+  # "{"data":{"type":"dois","attributes":{"prefix":"10.33555","event":"publish"}}}"
+  def build_state_update(doi_state)
+    add_event(doi_state)
+  end
+
+  def generate_json_payload
+    JSON.generate(data: @data_hash)
+  end
+
+  # for now, don't differentiate the event based on the current DOI state
+  def add_event(doi_desired_state, _doi_current_state = nil)
+    @attributes[:event] = DOI_MINT_EVENT[doi_desired_state] unless doi_desired_state.eql? :draft
+  end
+end

--- a/lib/hyacinth/adapters/external_identifier_adapter/memory.rb
+++ b/lib/hyacinth/adapters/external_identifier_adapter/memory.rb
@@ -62,11 +62,6 @@ module Hyacinth
           @identifiers[id][:status] = :inactive
           true
         end
-
-        private
-
-          # TODO: Remove this method when there's a general logging proxy
-          def log(status, message); end
       end
     end
   end

--- a/spec/fixtures/files/datacite/ezid_item.json
+++ b/spec/fixtures/files/datacite/ezid_item.json
@@ -58,6 +58,13 @@
             }
 	]
 	,
+	"publisher" :
+	[
+            {
+		"value" : "The Best Publisher Ever"
+            }
+	]
+	,
 	"name" :
 	[
             {

--- a/spec/hyacinth/adapters/external_identifier_adapter/datacite/metadata_spec.rb
+++ b/spec/hyacinth/adapters/external_identifier_adapter/datacite/metadata_spec.rb
@@ -86,13 +86,6 @@ describe Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::Metadata do
       expect(actual_doi).to eq(expected_doi)
     end
 
-    it "handle_net_identifier handles empty descriptive metadata" do
-      local_metadata_retrieval = described_class.new dod_empty_dfd
-      expected_handle_net_identifier = nil
-      actual_handle_net_identifier = local_metadata_retrieval.handle_net_identifier
-      expect(actual_handle_net_identifier).to eq(expected_handle_net_identifier)
-    end
-
     it "subjects_topic handles empty descriptive metadata" do
       local_metadata_retrieval = described_class.new dod_empty_dfd
       expected_subjects_topic = []
@@ -142,6 +135,15 @@ describe Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::Metadata do
       expected_abstract = 'This is an abstract; yes, a very nice abstract'
       actual_abstract = local_metadata_retrieval.abstract
       expect(actual_abstract).to eq(expected_abstract)
+    end
+  end
+
+  context "#publisher:" do
+    it "publisher" do
+      local_metadata_retrieval = described_class.new dod
+      expected_publisher = 'The Best Publisher Ever'
+      actual_publisher = local_metadata_retrieval.publisher
+      expect(actual_publisher).to eq(expected_publisher)
     end
   end
 
@@ -204,15 +206,6 @@ describe Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::Metadata do
     it "doi" do
       local_metadata_retrieval = described_class.new dod
       actual = local_metadata_retrieval.doi
-      expect(actual).to eq(expected)
-    end
-  end
-
-  context "#handle_net_identifier" do
-    let(:expected) { 'http://hdl.handle.net/10022/AC:P:29183' }
-    it "handle_net_identifier" do
-      local_metadata_retrieval = described_class.new dod
-      actual = local_metadata_retrieval.handle_net_identifier
       expect(actual).to eq(expected)
     end
   end

--- a/spec/hyacinth/adapters/external_identifier_adapter/datacite/rest_api/v2/api_spec.rb
+++ b/spec/hyacinth/adapters/external_identifier_adapter/datacite/rest_api/v2/api_spec.rb
@@ -59,12 +59,21 @@ describe Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::RestApi::V2::A
     end
   end
 
-  describe '#log' do
+  describe '#logger' do
+    let(:dev) { StringIO.new }
+    let(:log_level) { :warn }
+    let(:logger_config) { { log_level: log_level, dev: dev } }
+    let(:permitted_message) { 'Hello...' }
+    let(:filtered_message) { 'Goodbye...' }
+    let(:message_buffer) { dev.string.split }
+    before do
+      api.configure_logger(logger: logger_config)
+      api.logger.warn(permitted_message)
+      api.logger.info(filtered_message)
+    end
     it " log the api response" do
-      DATACITE[:log_api] = true
-      DATACITE[:log_level] = 'warn'
-      expect(Rails.logger).to receive(:warn).with('Hello...')
-      api.log('Hello...', 'warn')
+      expect(message_buffer).to include(permitted_message)
+      expect(message_buffer).not_to include(filtered_message)
     end
   end
 

--- a/spec/hyacinth/adapters/external_identifier_adapter/datacite/rest_api/v2/api_spec.rb
+++ b/spec/hyacinth/adapters/external_identifier_adapter/datacite/rest_api/v2/api_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::RestApi::V2::Api do
+  let(:api) { described_class.new('https://api.test.datacite.org', 'FriendlyUser', 'FriendlyPassword') }
+  let(:json_payload_update_doi) do
+    '
+    {"data":
+       {"type":"dois",
+        "attributes":
+          {"titles":
+             [{"title":"The Good Title"}],
+           "creators":
+             [{"name":"Doe, Jane"}],
+           "url":"https://www.columbia.edu",
+           "publisher":"Self",
+           "publicationYear":2002,
+           "types":
+             {"resourceTypeGeneral":"Text"},
+           "schemaVersion":"http://datacite.org/schema/kernel-4",
+           "prefix":"10.33555"}
+       }
+    }
+    '
+  end
+
+  let(:metadata) do
+    { type: 'dois',
+      attributes: {
+        doi: '10.33555/0645-3z82',
+        state: 'draft',
+        titles: [{ title: 'The Good Title' }],
+        creators: [{ name: "Doe, Jane" }],
+        url: 'https://www.columbia.edu',
+        publisher: 'Self',
+        publicationYear: 2002,
+        types: { resourceTypeGeneral: 'Text' },
+        schemaVersion: 'http://datacite.org/schema/kernel-4',
+        prefix: '10.33555'
+      } }
+  end
+  let(:mocked_headers) do
+    { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+      'Content-Type' => 'application/vnd.api+json', 'User-Agent' => 'Faraday v1.1.0' }
+  end
+  let(:api_response_body) do
+    { data: metadata }
+  end
+
+  describe '#get_dois' do
+    it " sends a GET request" do
+      data = Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::RestApi::V2::Data.new
+      stub_request(:post, "https://api.test.datacite.org/dois").with(
+        body: data.generate_json_payload,
+        headers: mocked_headers
+      ).to_return(status: 200, body: JSON.generate(api_response_body), headers: {})
+      api.post_dois(data.generate_json_payload)
+    end
+  end
+
+  describe '#log' do
+    it " log the api response" do
+      DATACITE[:log_api] = true
+      DATACITE[:log_level] = 'warn'
+      expect(Rails.logger).to receive(:warn).with('Hello...')
+      api.log('Hello...', 'warn')
+    end
+  end
+
+  describe '#parse_doi_from_api_response_body' do
+    it " parses the doi from the body of the API http response" do
+      expect(api.parse_doi_from_api_response_body(JSON.generate(api_response_body))).to eq('10.33555/0645-3z82')
+    end
+  end
+
+  describe '#parse_state_from_api_response_body' do
+    it " parses the state from the body of the API http response" do
+      expect(api.parse_state_from_api_response_body(JSON.generate(api_response_body))).to eq('draft')
+    end
+  end
+
+  describe '#parse_url_from_api_response_body' do
+    it " parses the target url from the body of the API http response" do
+      expect(api.parse_url_from_api_response_body(JSON.generate(api_response_body))).to eq('https://www.columbia.edu')
+    end
+  end
+
+  describe '#post_dois' do
+    it " sends a POST request" do
+      data = Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::RestApi::V2::Data.new
+      stub_request(:post, "https://api.test.datacite.org/dois").with(
+        headers: mocked_headers
+      ).to_return(status: 201, body: JSON.generate(api_response_body), headers: {})
+      api.post_dois(data.generate_json_payload)
+    end
+  end
+
+  describe '#put_dois' do
+    it " sends a PUT request" do
+      data = Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::RestApi::V2::Data.new
+      data.data_hash = metadata
+      stub_request(:put, "https://api.test.datacite.org/dois/10.33555/2Y0J-BC24").with(
+        body: json_payload_update_doi,
+        headers: mocked_headers
+      ).to_return(status: 200, body: "", headers: {})
+      api.put_dois('10.33555/2Y0J-BC24', json_payload_update_doi)
+    end
+  end
+end

--- a/spec/hyacinth/adapters/external_identifier_adapter/datacite/rest_api/v2/data_spec.rb
+++ b/spec/hyacinth/adapters/external_identifier_adapter/datacite/rest_api/v2/data_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::RestApi::V2::Data do
+  let(:data) { described_class.new('10.33555') }
+
+  let(:expected_attributes_hash) do
+    {
+      creators: [{ name: "Mouse, Minnie" }, { name: "Mouse, Mickey" }],
+      prefix: "10.33555",
+      publicationYear: 2021,
+      publisher: "Mouse Publishing",
+      schemaVersion: "http://datacite.org/schema/kernel-4",
+      titles: [{ title: "Mouse Hackers" }],
+      types: { resourceTypeGeneral: "Text" },
+      url: "www.example.com"
+    }
+  end
+
+  let(:expected_json_payload) do
+    '
+    {"data":
+       {"type":"dois",
+        "attributes":
+          {"prefix":"10.33555",
+           "creators":
+             [{"name":"Mouse, Minnie"},{"name":"Mouse, Mickey"}],
+           "titles":
+             [{"title":"Mouse Hackers"}],
+           "publisher":"Mouse Publishing",
+           "publicationYear":2021,
+           "types":
+             {"resourceTypeGeneral":"Text"},
+           "url":"www.example.com",
+           "schemaVersion":"http://datacite.org/schema/kernel-4"}
+       }
+    }
+    '
+  end
+
+  before do
+    data.creators = ['Mouse, Minnie', 'Mouse, Mickey']
+    data.prefix = '10.33555'
+    data.publisher = 'Mouse Publishing'
+    data.publication_year = 2021
+    data.resource_type_general = 'Text'
+    data.title = 'Mouse Hackers'
+    data.url = 'www.example.com'
+  end
+
+  describe "#add_properties_to_attributes_hash" do
+    it " add the metadata to the attributes hash correctly" do
+      # attributes set in the before clause
+      data.add_properties_to_attributes_hash
+      expect(data.attributes).to eql(expected_attributes_hash)
+    end
+  end
+
+  describe "#build_mint" do
+    it " builds mint payload as a hash (default: no metadata to be sent)" do
+      data_mint = described_class.new('10.33555')
+      data_mint.build_mint(:draft)
+      expect(data_mint.data_hash).to eql(type: 'dois', attributes: { prefix: '10.33555' })
+    end
+
+    it " builds mint payload as a hash (with metadata set to true)" do
+      # attributes set in the before clause
+      data.build_mint(:draft, true)
+      expect(data.data_hash).to eql(type: 'dois', attributes: expected_attributes_hash)
+    end
+  end
+
+  describe "#build_properties_update" do
+    it " builds an update payload as a hash, no state change" do
+      # properties set in the before clause
+      data.build_properties_update
+      expect(data.data_hash).to eql(type: 'dois', attributes: expected_attributes_hash)
+    end
+    it " builds an update payload as a hash, state set to findable" do
+      # properties set in the before clause
+      data.build_properties_update(:findable)
+      expect(data.data_hash).to eql(type: 'dois',
+                                    attributes: expected_attributes_hash.merge(event: 'publish'))
+    end
+  end
+
+  describe "#build_state_update" do
+    it " builds an state update payload as a hash, state set to findable" do
+      data.build_state_update(:findable)
+      expect(data.data_hash).to eql(type: 'dois',
+                                    attributes: { event: 'publish', prefix: '10.33555' })
+    end
+  end
+
+  describe "#generate_json_payload" do
+    it " builds an state update payload as a hash, state set to findable" do
+      # attributes set in the before clause
+      data.build_mint(:draft, true)
+      expect(data.generate_json_payload).to eql(expected_json_payload.gsub(/\n\s+/, ''))
+    end
+  end
+
+  describe '#add_event' do
+    it " add the correct event for the given desired state" do
+      data.add_event(:findable)
+      expect(data.data_hash).to eql(type: 'dois',
+                                    attributes: { event: 'publish', prefix: '10.33555' })
+    end
+  end
+end

--- a/spec/hyacinth/adapters/external_identifier_adapter/datacite_spec.rb
+++ b/spec/hyacinth/adapters/external_identifier_adapter/datacite_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite do
+  let(:datacite) { described_class.new }
+  let(:dod) do
+    data = JSON.parse(file_fixture('files/datacite/ezid_item.json').read)
+    data['identifiers'] = ['item.' + SecureRandom.uuid] # random identifer to avoid collisions
+    data
+  end
+  let(:metadata) do
+    { type: 'dois',
+      attributes: {
+        doi: '10.33555/0645-3z82',
+        state: 'draft',
+        titles: [{ title: 'The Good Title' }],
+        creators: [{ name: "Doe, Jane" }],
+        url: 'https://www.columbia.edu',
+        publisher: 'Self',
+        publicationYear: 2002,
+        types: { resourceTypeGeneral: 'Text' },
+        schemaVersion: 'http://datacite.org/schema/kernel-4',
+        prefix: '10.33555'
+      } }
+  end
+  let(:metadata_payload_json) do
+    '
+    {"data":
+       {"type":"dois",
+        "attributes":
+          {"prefix":"10.33555",
+           "creators":
+             [{"name":"Salinger, J. D."},{"name":"Lincoln, Abraham"}],
+           "titles":
+             [{"title":"The Catcher in the Rye"}],
+           "publisher":"The Best Publisher Ever",
+           "publicationYear":1951,
+           "types":
+             {"resourceTypeGeneral":"Image"},
+           "url":"https://www.columbia.edu",
+           "schemaVersion":"http://datacite.org/schema/kernel-4"}
+       }
+    }
+    '
+  end
+  let(:mocked_headers) do
+    { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+      'Content-Type' => 'application/vnd.api+json', 'User-Agent' => 'Faraday v1.1.0' }
+  end
+  let(:mocked_headers_no_content) do
+    { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+      'User-Agent' => 'Faraday v1.1.0' }
+  end
+  let(:no_metadata_response_body_json) do
+    '{"data":
+       {"id":"10.33555/tb9q-qb07",
+        "type":"dois",
+        "attributes":
+          {"doi":"10.33555/tb9q-qb07"}
+       }
+    }'
+  end
+  let(:doi_not_found_response_body_json) do
+    "{\"errors\":
+       [{\"status\":\"404\",\"title\":\"The resource you are looking for does'nt exist.\"}]
+    }"
+  end
+
+  before do
+    DATACITE[:rest_api] = 'https://api.test.datacite.org'
+    DATACITE[:user] = 'FriendlyUser'
+    DATACITE[:password] = 'FriendlyPassword'
+    DATACITE[:prefix] = '10.33555'
+  end
+
+  describe '#exists?' do
+    it " returns true for a DOI that is present in DataCite" do
+      stub_request(:get, "https://api.test.datacite.org/dois/10.33555/tb9q-qb07").with(
+        headers: mocked_headers_no_content
+      ).to_return(status: 200, body: no_metadata_response_body_json, headers: {})
+      expect(datacite.exists?('10.33555/tb9q-qb07')).to be_truthy
+    end
+
+    it " returns false for a DOI that is not present in DataCite" do
+      stub_request(:get, "https://api.test.datacite.org/dois/10.33555/tb9q-qb07abc").with(
+        headers: mocked_headers_no_content
+      ).to_return(status: 404, body: doi_not_found_response_body_json, headers: {})
+      expect(datacite.exists?('10.33555/tb9q-qb07abc')).to be_falsey
+    end
+  end
+
+  describe '#mint' do
+    it " no metadata supplied. Calls the appropriate Api method" do
+      stub_request(:post, "https://api.test.datacite.org/dois").with(
+        headers: mocked_headers,
+        body: '{"data":{"type":"dois","attributes":{"prefix":"10.33555"}}}'
+      ).to_return(status: 201, body: no_metadata_response_body_json, headers: {})
+      datacite.mint
+    end
+
+    it " metadata supplied (via Datacite::Metadata instance). Calls the appropriate Api method, " do
+      metadata = Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::Metadata.new dod
+      stub_request(:post, "https://api.test.datacite.org/dois").with(
+        headers: mocked_headers,
+        body: metadata_payload_json.gsub(/\n\s+/, '')
+      ).to_return(status: 201, body: no_metadata_response_body_json, headers: {})
+      datacite.mint(metadata, 'https://www.columbia.edu')
+    end
+  end
+
+  describe '#update_doi' do
+    it " calls the appropriate Api method" do
+      metadata = Hyacinth::Adapters::ExternalIdentifierAdapter::Datacite::Metadata.new dod
+      stub_request(:put, "https://api.test.datacite.org/dois/10.33555/tb9q-qb07").with(
+        headers: mocked_headers,
+        body: metadata_payload_json.gsub(/\n\s+/, '')
+      ).to_return(status: 200, body: no_metadata_response_body_json, headers: {})
+      datacite.update_doi('10.33555/tb9q-qb07', metadata, 'https://www.columbia.edu')
+    end
+  end
+
+  describe '#update_doi_target_url' do
+    it " calls the appropriate Api method" do
+      stub_request(:put, "https://api.test.datacite.org/dois/10.33555/tb9q-qb07").with(
+        headers: mocked_headers,
+        body: '{"data":{"type":"dois","attributes":{"prefix":"10.33555","url":"https://www.columbia.edu","schemaVersion":"http://datacite.org/schema/kernel-4"}}}'
+      ).to_return(status: 200, body: no_metadata_response_body_json, headers: {})
+      datacite.update_doi_target_url('10.33555/tb9q-qb07', 'https://www.columbia.edu')
+    end
+  end
+end


### PR DESCRIPTION
Example technique for having optional logging configurations that otherwise adhere to the usual Rails logger API