### PR TITLE
move lazy load of FontAwesomeIcon out of function body into module constant

### DIFF
--- a/app/javascript/src/hyacinth_v1/utils/lazyFontAwesome.js
+++ b/app/javascript/src/hyacinth_v1/utils/lazyFontAwesome.js
@@ -1,9 +1,10 @@
 import React, { Suspense } from 'react';
 import PropTypes from 'prop-types';
 
+const FontAwesomeIcon = React.lazy(() => import(/* webpackChunkName: 'fontAwesome' */ './fontAwesome'));
+
 const LazyFontAwesomeIcon = (props) => {
   const { fallback, icon, ...rest } = props;
-  const FontAwesomeIcon = React.lazy(() => import(/* webpackChunkName: 'fontAwesome' */ './fontAwesome'));
   return <Suspense fallback={fallback}><FontAwesomeIcon icon={icon} { ...rest } /></Suspense>;
 };
 


### PR DESCRIPTION
Declaring FontAwesomeIcon in component body reloads at runtime causing fallback to be used unnecessarily  (HYACINTH-883)