### PR TITLE
refactor doi assignment concern's spec to clarify test cases

### DIFF
--- a/spec/models/concerns/digital_object_concerns/attribute_assignment/doi_spec.rb
+++ b/spec/models/concerns/digital_object_concerns/attribute_assignment/doi_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe DigitalObjectConcerns::AttributeAssignment::Doi do
   include_context 'with stubbed search adapters'
-  let(:digital_object) { FactoryBot.build(:digital_object_test_subclass) }
+  let(:digital_object_without_doi) { FactoryBot.build(:digital_object_test_subclass) }
   let(:doi) { 'abc/123' }
   let(:digital_object_data_with_doi) do
     {
@@ -24,6 +24,7 @@ RSpec.describe DigitalObjectConcerns::AttributeAssignment::Doi do
 
   describe "#assign_doi" do
     context "when no doi has been set" do
+      let(:digital_object) { digital_object_without_doi }
       it "sets the doi" do
         digital_object.assign_doi(digital_object_data_with_doi)
         expect(digital_object.doi).to eq(doi)
@@ -31,23 +32,25 @@ RSpec.describe DigitalObjectConcerns::AttributeAssignment::Doi do
     end
 
     context "when a doi has already been set" do
+      let(:digital_object) { digital_object_with_doi }
       it "raises an error if a different value is supplied" do
-        expect { digital_object_with_doi.assign_doi(digital_object_data_with_different_doi) }.to raise_error(Hyacinth::Exceptions::AlreadySet)
+        expect { digital_object.assign_doi(digital_object_data_with_different_doi) }.to raise_error(Hyacinth::Exceptions::AlreadySet)
       end
 
       it "does not raise an error if the existing value is supplied" do
-        expect { digital_object_with_doi.assign_doi(digital_object_data_with_doi) }.not_to raise_error
+        expect { digital_object.assign_doi(digital_object_data_with_doi) }.not_to raise_error
       end
 
       it "does not clear the doi when digital object data with no doi key is supplied" do
-        digital_object_with_doi.assign_doi({})
-        expect(digital_object_with_doi.doi).to eq(doi)
+        digital_object.assign_doi({})
+        expect(digital_object.doi).to eq(doi)
       end
     end
   end
 
   describe "#assign_mint_doi" do
     context "when no doi has been set, it sets @mint_doi to the given value, converted to a boolean value" do
+      let(:digital_object) { digital_object_without_doi }
       {
         true => true,
         false => false,
@@ -65,25 +68,29 @@ RSpec.describe DigitalObjectConcerns::AttributeAssignment::Doi do
     end
 
     context "when a doi has already been set" do
+      let(:digital_object) { digital_object_with_doi }
       it "always keeps a false value for @mint_doi" do
-        expect(digital_object_with_doi.instance_variable_get('@mint_doi')).to eq(false)
-        digital_object_with_doi.assign_mint_doi('mint_doi' => true)
-        expect(digital_object_with_doi.instance_variable_get('@mint_doi')).to eq(false)
+        expect(digital_object.instance_variable_get('@mint_doi')).to eq(false)
+        digital_object.assign_mint_doi('mint_doi' => true)
+        expect(digital_object.instance_variable_get('@mint_doi')).to eq(false)
       end
     end
   end
   describe "#ensure_doi_if_requested" do
-    let(:mint_doi) { true }
-    before { digital_object_with_doi.mint_doi = mint_doi }
+    before { digital_object.mint_doi = mint_doi }
     context "when a doi has already been set" do
+      let(:mint_doi) { true }
+      let(:digital_object) { digital_object_with_doi }
       it "does not call ensure_doi in save hook" do
         expect(Hyacinth::Config.external_identifier_adapter).not_to receive(:mint)
-        digital_object_with_doi.save
-        expect(digital_object_with_doi.mint_doi).to be false
+        digital_object.save
+        expect(digital_object.mint_doi).to be false
       end
     end
     context "when a doi has not been set" do
+      let(:digital_object) { digital_object_without_doi }
       context "and @mint_doi is false" do
+        let(:mint_doi) { false }
         it "does not call ensure_doi in save hook" do
           expect(digital_object).not_to receive(:ensure_doi)
           digital_object.save
@@ -91,8 +98,9 @@ RSpec.describe DigitalObjectConcerns::AttributeAssignment::Doi do
         end
       end
       context "and @mint_doi is true" do
+        let(:mint_doi) { true }
         it "calls ensure_doi in save hook" do
-          expect(digital_object).not_to receive(:ensure_doi)
+          expect(digital_object).to receive(:ensure_doi)
           digital_object.save
           expect(digital_object.mint_doi).to be false
         end


### PR DESCRIPTION
- update false pass for verifying ensure_doi called in save hook
- HYACINTH-393