### PR TITLE
use I18n for flash messages in Hyacinth::Users::CasAuthenticationBehavior

### DIFF
--- a/app/controllers/concerns/hyacinth/users/cas_authentication_behavior.rb
+++ b/app/controllers/concerns/hyacinth/users/cas_authentication_behavior.rb
@@ -61,7 +61,7 @@ module Hyacinth
 
               redirect_to root_path, status: 302
             else
-              flash[:alert] = possible_user.present? ? I18n.t('devise.failure.inactive') : I18n.t('devise.failure.unauthorized', uid: user_uni, email: user_email)
+              flash[:alert] = possible_user.present? ? I18n.t('devise.failure.inactive') : I18n.t('devise.failure.unauthorized', uni: user_uni, email: user_email)
               # Log out user
               redirect_to(cas_logout_uri + '?service=' + URI.encode_www_form_component(root_url))
             end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -16,7 +16,7 @@ en:
       provider: "%{provider} Authentication failed, Please try again later."
       timeout: "Your session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
-      unauthorized: "The UNI %{uid} is not authorized to log into Hyacinth (no account exists with email %{email}).  If you believe that you should have access, please contact an application administrator."
+      unauthorized: "The UNI %{uni} is not authorized to log into Hyacinth (no account exists with email %{email}).  If you believe that you should have access, please contact an application administrator."
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -13,8 +13,10 @@ en:
       locked: "Your account is locked."
       last_attempt: "You have one more attempt before your account is locked."
       not_found_in_database: "Invalid %{authentication_keys} or password."
+      provider: "%{provider} Authentication failed, Please try again later."
       timeout: "Your session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
+      unauthorized: "The UNI %{uid} is not authorized to log into Hyacinth (no account exists with email %{email}).  If you believe that you should have access, please contact an application administrator."
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:

--- a/lib/hyacinth/digital_object/resource_attributes.rb
+++ b/lib/hyacinth/digital_object/resource_attributes.rb
@@ -93,9 +93,8 @@ module Hyacinth
       def validate_resource_attribute_config(resource_attribute_name, config)
         preservable_config = config[:preservable]
         return unless preservable.present?
-        unless preservable_config[:as] == :copy || preservable_config[:as] == :reference
-          raise "Cannot define #{resource_attribute_name}: preservable resources must be :copy or :reference (got #{preservable_config[:as]})"
-        end
+        valid_preservable_as = (preservable_config[:as] == :copy || preservable_config[:as] == :reference)
+        raise "Cannot define #{resource_attribute_name}: preservable resources must be :copy or :reference (got #{preservable_config[:as]})" unless valid_preservable_as
         versionable = preservable_config[:versionable]
         raise "Cannot define #{resource_attribute_name}: preservable resources may only have true/false values for versionable (got #{versionable})" unless nil_or_boolean?(versionable)
         verify_checksum = preservable_config[:verify_checksum]


### PR DESCRIPTION
Pulling this style conformance/message template work out of the HYACINTH-907 branch