### PR TITLE
HYACINTH-974: Specify -Xss1024k option for solr wrapper

### DIFF
--- a/config/templates/solr_wrapper.template.yml
+++ b/config/templates/solr_wrapper.template.yml
@@ -4,7 +4,7 @@ default: &default
   verbose: false
   managed: true
   solr_options:
-    "addlopts" : "-Djetty.host=127.0.0.1"
+    "addlopts" : "-Xss1024k -Djetty.host=127.0.0.1"
 
 development:
   <<: *default


### PR DESCRIPTION
(for compatibility with Azul Zulu Java 8, which seems to have a smaller default value than other distributions)