### PR TITLE
permit PCDM dc_type values for Assets if assigned (2.6.x)

### DIFF
--- a/app/assets/javascripts/digital_objects_app/models/digital_object/asset.js
+++ b/app/assets/javascripts/digital_objects_app/models/digital_object/asset.js
@@ -87,7 +87,7 @@ Hyacinth.DigitalObjectsApp.DigitalObject.Asset.prototype.getOriginalFilePath = f
 };
 
 Hyacinth.DigitalObjectsApp.DigitalObject.Asset.prototype.hasImage = function () {
-  return Hyacinth.imageServerUrl && this.getDcType() == 'StillImage';
+  return Hyacinth.imageServerUrl && this.isStillImage();
 };
 
 Hyacinth.DigitalObjectsApp.DigitalObject.Asset.prototype.isRestrictedSizeImage = function () {

--- a/app/assets/javascripts/digital_objects_app/models/digital_object/base.js
+++ b/app/assets/javascripts/digital_objects_app/models/digital_object/base.js
@@ -76,6 +76,14 @@ Hyacinth.DigitalObjectsApp.DigitalObject.Base.prototype.getStateAsDisplayLabel =
   return statesToDisplayLabels[this.getState()];
 };
 
+Hyacinth.DigitalObjectsApp.DigitalObject.Base.prototype.isAudioMovingImage = function () {
+  return ['Audio','MovingImage', 'Sound', 'Video'].includes(this.dc_type);
+};
+
+Hyacinth.DigitalObjectsApp.DigitalObject.Base.prototype.isStillImage = function () {
+  return ['Image','StillImage'].includes(this.dc_type);
+};
+
 Hyacinth.DigitalObjectsApp.DigitalObject.Base.prototype.isNewRecord = function () {
   return (this.getPid() == null);
 };

--- a/app/assets/javascripts/digital_objects_app/models/digital_object_search_result.js
+++ b/app/assets/javascripts/digital_objects_app/models/digital_object_search_result.js
@@ -18,6 +18,14 @@ Hyacinth.DigitalObjectsApp.DigitalObjectSearchResult.prototype.getDcType = funct
   return this.dcType;
 };
 
+Hyacinth.DigitalObjectsApp.DigitalObjectSearchResult.prototype.isAudioMovingImage = function(){
+  return ['Audio','MovingImage', 'Sound', 'Video'].includes(this.dcType);
+};
+
+Hyacinth.DigitalObjectsApp.DigitalObjectSearchResult.prototype.isStillImage = function(){
+  return ['Image', 'StillImage'].includes(this.dcType);
+};
+
 Hyacinth.DigitalObjectsApp.DigitalObjectSearchResult.prototype.getPid = function(){
   return this.pid;
 };

--- a/app/assets/javascripts/digital_objects_app/widgets/digital_object_annotation_editor.js
+++ b/app/assets/javascripts/digital_objects_app/widgets/digital_object_annotation_editor.js
@@ -36,7 +36,7 @@ Hyacinth.DigitalObjectsApp.DigitalObjectAnnotationEditor.prototype.init = functi
   this.$containerElement.addClass(Hyacinth.DigitalObjectsApp.DigitalObjectAnnotationEditor.ANNOTATION_EDITOR_ELEMENT_CLASS); //Add class to container element
   this.$containerElement.data(Hyacinth.DigitalObjectsApp.DigitalObjectAnnotationEditor.ANNOTATION_EDITOR_DATA_KEY, this); //Assign this editor object as data to the container element so that we can access it later
 
-  if(['MovingImage', 'Sound'].indexOf(this.digitalObject.getDcType()) > -1) {
+  if(this.digitalObject.isAudioMovingImage()) {
     this.$containerElement.html(
       Hyacinth.DigitalObjectsApp.renderTemplate('digital_objects_app/widgets/digital_object_annotation_editor/oh_synchronizer_index_mode.ejs', {
         digitalObject: this.digitalObject,

--- a/app/assets/javascripts/digital_objects_app/widgets/digital_object_synchronized_transcript_editor.js
+++ b/app/assets/javascripts/digital_objects_app/widgets/digital_object_synchronized_transcript_editor.js
@@ -36,7 +36,7 @@ Hyacinth.DigitalObjectsApp.DigitalObjectSynchronizedTranscriptEditor.prototype.i
   this.$containerElement.addClass(Hyacinth.DigitalObjectsApp.DigitalObjectSynchronizedTranscriptEditor.SYNCHRONIZED_TRANSCRIPT_EDITOR_ELEMENT_CLASS); //Add class to container element
   this.$containerElement.data(Hyacinth.DigitalObjectsApp.DigitalObjectSynchronizedTranscriptEditor.SYNCHRONIZED_TRANSCRIPT_EDITOR_DATA_KEY, this); //Assign this editor object as data to the container element so that we can access it later
 
-  if (['MovingImage', 'Sound'].indexOf(this.digitalObject.getDcType()) > -1) {
+  if(this.digitalObject.isAudioMovingImage()) {
     this.$containerElement.html(
       Hyacinth.DigitalObjectsApp.renderTemplate('digital_objects_app/widgets/digital_object_synchronized_transcript_editor/oh_synchronizer_transcript_mode.ejs', {
         digitalObject: this.digitalObject,

--- a/app/assets/templates/digital_objects_app/digital_objects/show.ejs
+++ b/app/assets/templates/digital_objects_app/digital_objects/show.ejs
@@ -23,22 +23,21 @@ if (digitalObject.digital_object_type.string_key == 'asset') {
                  Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects',
                                                                action: 'manage_transcript',
                                                                pid: Hyacinth.DigitalObjectsApp.params['pid']})});
-}
+  if (digitalObject.isAudioMovingImage()) {
+    navItems.push({label: '<span class="glyphicon glyphicon-edit"></span> Annotation', url: '#' +
+                   Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects',
+                                                                 action: 'manage_annotation',
+                                                                 pid: Hyacinth.DigitalObjectsApp.params['pid']})});
 
-if (digitalObject.digital_object_type.string_key == 'asset' && (digitalObject.getDcType() == 'MovingImage' || digitalObject.getDcType() == 'Sound')) {
-  navItems.push({label: '<span class="glyphicon glyphicon-edit"></span> Annotation', url: '#' +
-                 Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects',
-                                                               action: 'manage_annotation',
-                                                               pid: Hyacinth.DigitalObjectsApp.params['pid']})});
-
-  navItems.push({label: '<span class="glyphicon glyphicon-edit"></span> Synchronized Transcript', url: '#' +
-                Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects',
-                                                              action: 'manage_synchronized_transcript',
-                                                              pid: Hyacinth.DigitalObjectsApp.params['pid']})});
-  navItems.push({label: '<span class="glyphicon glyphicon-edit"></span> Captions', url: '#' +
-                Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects',
-                                                              action: 'manage_captions',
-                                                              pid: Hyacinth.DigitalObjectsApp.params['pid']})});
+    navItems.push({label: '<span class="glyphicon glyphicon-edit"></span> Synchronized Transcript', url: '#' +
+                  Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects',
+                                                                action: 'manage_synchronized_transcript',
+                                                                pid: Hyacinth.DigitalObjectsApp.params['pid']})});
+    navItems.push({label: '<span class="glyphicon glyphicon-edit"></span> Captions', url: '#' +
+                  Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects',
+                                                                action: 'manage_captions',
+                                                                pid: Hyacinth.DigitalObjectsApp.params['pid']})});
+  }
 }
 
 if (hasUpdatePermission) {

--- a/app/assets/templates/digital_objects_app/widgets/digital_object_editor/_header.ejs
+++ b/app/assets/templates/digital_objects_app/widgets/digital_object_editor/_header.ejs
@@ -299,7 +299,7 @@
           <h4 class="preview-heading">Asset</h4>
           <img class="img-responsive thumbnail" src="<%= Hyacinth.DigitalObjectsApp.DigitalObject.Base.getImageUrl(digitalObject.getPid(), 'scaled', 256) %>" title="<%= digitalObject.getPid() %>" />
           <div class="caption">
-            <% if (digitalObject.getDcType() == 'StillImage') { %>
+            <% if (digitalObject.isStillImage()) { %>
               <a href="#" class="btn btn-block btn-primary btn-xs" onclick="Hyacinth.DigitalObjectsApp.DigitalObject.Base.showMediaViewModal('<%= digitalObject.getPid() %>'); return false;">View Zoomable Image</a>
               <% if (mode == 'show') { %>
                 <br />
@@ -314,7 +314,7 @@
                   </ul>
                 </div>
               <% } %>
-            <% } else if (['Sound','MovingImage'].includes(digitalObject.getDcType())) { %>
+            <% } else if (digitalObject.isAudioMovingImage()) { %>
               <a href="#" class="btn btn-block btn-primary btn-xs" onclick="Hyacinth.DigitalObjectsApp.DigitalObject.Base.showMediaViewModal('<%= digitalObject.getPid() %>'); return false;">View Media</a>
             <% } %>
           </div>

--- a/app/controllers/assignments/changesets_controller.rb
+++ b/app/controllers/assignments/changesets_controller.rb
@@ -36,7 +36,7 @@ class Assignments::ChangesetsController < ApplicationController
       end
     when 'annotate_object'
       if index_document_params[:index_document_text]
-        if ['MovingImage', 'Sound'].include?(digital_object.dc_type)
+        if digital_object.audio_moving_image?
           create_or_update_annotate_changeset(@assignment, digital_object, index_document_params[:index_document_text])
           @assignment.save
         else
@@ -45,7 +45,7 @@ class Assignments::ChangesetsController < ApplicationController
       end
     when 'synchronize'
       if synchronized_transcript_params[:synchronized_transcript_text]
-        if ['MovingImage', 'Sound'].include?(digital_object.dc_type)
+        if digital_object.audio_moving_image?
           create_or_update_synchronize_changeset(@assignment, digital_object, synchronized_transcript_params[:synchronized_transcript_text])
           @assignment.save
         else
@@ -86,7 +86,7 @@ class Assignments::ChangesetsController < ApplicationController
     end
 
     def create_or_update_annotate_changeset(assignment, digital_object, new_content)
-      if ['MovingImage', 'Sound'].include?(digital_object.dc_type)
+      if digital_object.audio_moving_image?
         assignment.original = digital_object.index_document if assignment.original.nil?
       else
         raise 'Not implemented yet'
@@ -95,7 +95,7 @@ class Assignments::ChangesetsController < ApplicationController
     end
 
     def create_or_update_synchronize_changeset(assignment, digital_object, new_content)
-      if ['MovingImage', 'Sound'].include?(digital_object.dc_type)
+      if digital_object.audio_moving_image?
         assignment.original = digital_object.synchronized_transcript if assignment.original.nil?
       else
         raise 'Not implemented yet'

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -34,7 +34,7 @@ class AssignmentsController < ApplicationController
       @assignment.proposed = @assignment.original
     when 'annotate_object'
       # store current state of transcript in *original* field
-      if ['MovingImage', 'Sound'].include?(@digital_object.dc_type)
+      if @digital_object.audio_moving_image?
         @assignment.original = @digital_object.index_document
       else
         raise 'Not implemented yet'
@@ -43,7 +43,7 @@ class AssignmentsController < ApplicationController
       @assignment.proposed = @assignment.original
     when 'synchronize'
       # store current state of transcript in *original* field
-      if ['MovingImage', 'Sound'].include?(@digital_object.dc_type)
+      if @digital_object.audio_moving_image?
         @assignment.original = @digital_object.synchronized_transcript
       else
         raise 'Not implemented yet'
@@ -124,13 +124,13 @@ class AssignmentsController < ApplicationController
       digital_object.transcript = @assignment.proposed
     when 'annotate_object'
       # TODO: Probably change index_document to annotation
-      if ['MovingImage', 'Sound'].include?(digital_object.dc_type)
+      if digital_object.audio_moving_image?
         digital_object.index_document = @assignment.proposed
       else
         raise 'Not implemented yet'
       end
     when 'synchronize'
-      if ['MovingImage', 'Sound'].include?(digital_object.dc_type)
+      if digital_object.audio_moving_image?
         digital_object.synchronized_transcript = @assignment.proposed
       else
         raise "Cannot commit synchronized transcript for non-audiovisual resource (pid: #{digital_object.pid}, dc_type: #{digital_object.dc_type})"

--- a/app/controllers/digital_objects_controller.rb
+++ b/app/controllers/digital_objects_controller.rb
@@ -262,7 +262,7 @@ class DigitalObjectsController < ApplicationController
   end
 
   def rotate_image
-    unless @digital_object.is_a?(DigitalObject::Asset) && @digital_object.dc_type == 'StillImage'
+    unless @digital_object.is_a?(DigitalObject::Asset) && @digital_object.still_image?
       render json: { errors: ["Only Assets of type StillImage can be rotated.  This is a #{@digital_object.digital_object_type.display_label} of type #{@digital_object.dc_type}"] }
       return
     end

--- a/app/models/digital_object/asset.rb
+++ b/app/models/digital_object/asset.rb
@@ -9,8 +9,12 @@ class DigitalObject::Asset < DigitalObject::Base
   include DigitalObject::Assets::Captions
   include Hyacinth::Utils::StringUtils
 
-  UNKNOWN_DC_TYPE = 'Unknown'
-  VALID_DC_TYPES = [UNKNOWN_DC_TYPE, 'Dataset', 'MovingImage', 'Software', 'Sound', 'StillImage', 'Text']
+  UNKNOWN_DC_TYPE = BestType::PcdmTypeLookup::UNKNOWN
+  ASSET_DC_TYPES = ['Dataset', 'MovingImage', 'Software', 'Sound', 'StillImage', 'Text']
+  VALID_DC_TYPES = (BestType::PcdmTypeLookup::VALID_TYPES + ASSET_DC_TYPES).uniq
+  AMI_DC_TYPES = ['Audio', 'MovingImage', 'Sound', 'Video']
+  IMAGE_DC_TYPES = ['Image', 'StillImage']
+
   DIGITAL_OBJECT_TYPE_STRING_KEY = 'asset'
 
   DEFAULT_ASSET_NAME = 'Asset' # For when a title is not supplied and we're not doing with a filesystem upload
@@ -403,6 +407,14 @@ class DigitalObject::Asset < DigitalObject::Base
     if synchronized_transcript_changed?
       IO.write(self.synchronized_transcript_location, self.synchronized_transcript)
     end
+  end
+
+  def audio_moving_image?
+    AMI_DC_TYPES.include?(self.dc_type || BestType.dc_type.for_file_name(self.original_filename))
+  end
+
+  def still_image?
+    IMAGE_DC_TYPES.include?(self.dc_type || BestType.dc_type.for_file_name(self.original_filename))
   end
 
   def player_mime_type

--- a/app/models/digital_object/base.rb
+++ b/app/models/digital_object/base.rb
@@ -259,6 +259,14 @@ class DigitalObject::Base
     self::VALID_DC_TYPES
   end
 
+  def audio_moving_image?
+    false
+  end
+
+  def still_image?
+    false
+  end
+
   def allowed_publish_targets
     DigitalObject::PublishTarget.basic_publish_target_data_from_solr(project.enabled_publish_target_pids)
   end

--- a/app/views/digital_objects/media_view.html.erb
+++ b/app/views/digital_objects/media_view.html.erb
@@ -1,4 +1,4 @@
-<% if @digital_object.dc_type == 'StillImage' %>
+<% if @digital_object.still_image? %>
 
   <script>
     $(document).ready(function(){
@@ -154,7 +154,7 @@
       </span>
     </div>
   </div>
-<% elsif ['Sound','MovingImage'].include? @digital_object.dc_type %>
+<% elsif @digital_object.audio_moving_image? %>
   <% media_url = @digital_object.player_url(request.remote_ip) %>
   <% media_mime_type = @digital_object.player_mime_type %>
   <div id="media-content" style="width: 800px; height: 600px;">

--- a/spec/models/digital_object/asset_spec.rb
+++ b/spec/models/digital_object/asset_spec.rb
@@ -184,4 +184,46 @@ RSpec.describe DigitalObject::Asset, :type => :model do
       expect(asset.perform_derivative_processing).to eq(false)
     end
   end
+  describe 'audio_moving_image?' do
+    let(:asset) { DigitalObject::Asset.new }
+    it "is true when appropriate dc_type value from DC" do
+      asset.instance_variable_set(:@dc_type, 'MovingImage')
+      expect(asset.audio_moving_image?).to be true     
+      asset.instance_variable_set(:@dc_type, 'Sound')
+      expect(asset.audio_moving_image?).to be true    
+    end    
+    it "is false when inappropriate dc_type value from DC" do
+      asset.instance_variable_set(:@dc_type, 'Dataset')
+      expect(asset.audio_moving_image?).to be false    
+    end    
+    it "is true when appropriate dc_type value from PCDM" do
+      asset.instance_variable_set(:@dc_type, 'Audio')
+      expect(asset.audio_moving_image?).to be true     
+      asset.instance_variable_set(:@dc_type, 'Video')
+      expect(asset.audio_moving_image?).to be true    
+    end    
+    it "is false when inappropriate dc_type value from PCDM" do
+      asset.instance_variable_set(:@dc_type, 'Spreadsheet')
+      expect(asset.audio_moving_image?).to be false    
+    end    
+  end
+  describe 'still_image?' do
+    let(:asset) { DigitalObject::Asset.new }
+    it "is true when appropriate dc_type value from DC" do
+      asset.instance_variable_set(:@dc_type, 'StillImage')
+      expect(asset.still_image?).to be true     
+    end    
+    it "is false when inappropriate dc_type value from DC" do
+      asset.instance_variable_set(:@dc_type, 'MovingImage')
+      expect(asset.still_image?).to be false    
+    end    
+    it "is true when appropriate dc_type value from PCDM" do
+      asset.instance_variable_set(:@dc_type, 'Image')
+      expect(asset.still_image?).to be true    
+    end    
+    it "is false when inappropriate dc_type value from PCDM" do
+      asset.instance_variable_set(:@dc_type, 'Video')
+      expect(asset.still_image?).to be false    
+    end    
+  end
 end


### PR DESCRIPTION
- consolidate tpye inspections behind methods on ruby and hs asset models