### PR TITLE
HYACINTH-1190: Import Jobs and DOIs - New API and UI

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "printWidth": 100
+}

--- a/app/controllers/api/v2/digital_object_imports_controller.rb
+++ b/app/controllers/api/v2/digital_object_imports_controller.rb
@@ -13,7 +13,7 @@ class Api::V2::DigitalObjectImportsController < Api::V2::BaseController
     @digital_object_imports = scope
       .order(csv_row_number: :asc)
       .page(params[:page])
-      .per(50)
+      .per(2) # temp
 
     render_camelized_json({
       digital_object_imports: @digital_object_imports.map { |doi| digital_object_import_list_json(doi) },

--- a/app/controllers/api/v2/digital_object_imports_controller.rb
+++ b/app/controllers/api/v2/digital_object_imports_controller.rb
@@ -34,6 +34,10 @@ class Api::V2::DigitalObjectImportsController < Api::V2::BaseController
 
     def set_import_job
       @import_job = ImportJob.find(params[:import_job_id])
+
+      # If the user is not authorized to view this import job, we also want to prevent them 
+      # from viewing the digital object imports that belong to this import job.
+      authorize! :show, @import_job
     end
 
     def set_digital_object_import

--- a/app/controllers/api/v2/digital_object_imports_controller.rb
+++ b/app/controllers/api/v2/digital_object_imports_controller.rb
@@ -13,7 +13,7 @@ class Api::V2::DigitalObjectImportsController < Api::V2::BaseController
     @digital_object_imports = scope
       .order(csv_row_number: :asc)
       .page(params[:page])
-      .per(2) # temp
+      .per(50)
 
     render_camelized_json({
       digital_object_imports: @digital_object_imports.map { |doi| digital_object_import_list_json(doi) },

--- a/app/controllers/api/v2/digital_object_imports_controller.rb
+++ b/app/controllers/api/v2/digital_object_imports_controller.rb
@@ -35,7 +35,7 @@ class Api::V2::DigitalObjectImportsController < Api::V2::BaseController
     def set_import_job
       @import_job = ImportJob.find(params[:import_job_id])
 
-      # If the user is not authorized to view this import job, we also want to prevent them 
+      # If the user is not authorized to view this import job, we also want to prevent them
       # from viewing the digital object imports that belong to this import job.
       authorize! :show, @import_job
     end

--- a/app/controllers/api/v2/digital_object_imports_controller.rb
+++ b/app/controllers/api/v2/digital_object_imports_controller.rb
@@ -64,6 +64,7 @@ class Api::V2::DigitalObjectImportsController < Api::V2::BaseController
     def digital_object_import_detail_json(doi)
       {
         id: doi.id,
+        import_job_id: doi.import_job_id,
         csv_row_number: doi.csv_row_number,
         status: doi.status,
         digital_object_data: doi.digital_object_data,
@@ -72,7 +73,6 @@ class Api::V2::DigitalObjectImportsController < Api::V2::BaseController
         # requeue_count: doi.requeue_count, // not displayed in old UI
         created_at: doi.created_at,
         updated_at: doi.updated_at,
-        import_job_id: doi.import_job_id
       }
     end
 end

--- a/app/controllers/api/v2/digital_object_imports_controller.rb
+++ b/app/controllers/api/v2/digital_object_imports_controller.rb
@@ -1,0 +1,78 @@
+class Api::V2::DigitalObjectImportsController < Api::V2::BaseController
+  before_action :set_import_job
+  before_action :set_digital_object_import, only: [:show]
+
+  # GET /api/v2/import_jobs/:import_job_id/digital_object_imports
+  # Optional query params: 
+  # - ?status=pending|success|failure 
+  # - ?page=N
+  def index
+    scope = @import_job.digital_object_imports
+    scope = scope.where(status: DigitalObjectImport.statuses[status_filter]) if status_filter
+
+    @digital_object_imports = scope
+      .order(csv_row_number: :asc)
+      .page(params[:page])
+      .per(50)
+
+    render_camelized_json({
+      digital_object_imports: @digital_object_imports.map { |doi| digital_object_import_list_json(doi) },
+      pagination: pagination_data(@digital_object_imports),
+      status_filter: status_filter,
+    })
+  end
+
+  # GET /api/v2/import_jobs/:import_job_id/digital_object_imports/:id
+  def show
+    render_camelized_json({ digital_object_import: digital_object_import_detail_json(@digital_object_import) })
+  end
+
+  private
+
+    def set_import_job
+      @import_job = ImportJob.find(params[:import_job_id])
+    end
+
+    def set_digital_object_import
+      @digital_object_import = @import_job.digital_object_imports.find(params[:id])
+    end
+
+    def status_filter
+      key = params[:status]
+      key.present? && DigitalObjectImport.statuses.key?(key) ? key : nil
+    end
+
+    def pagination_data(scope)
+      {
+        current_page: scope.current_page,
+        per_page: scope.limit_value,
+        total_pages: scope.total_pages,
+        total_count: scope.total_count
+      }
+    end
+
+    def digital_object_import_list_json(doi)
+      {
+        id: doi.id,
+        csv_row_number: doi.csv_row_number,
+        status: doi.status,
+        created_at: doi.created_at,
+        updated_at: doi.updated_at
+      }
+    end
+
+    def digital_object_import_detail_json(doi)
+      {
+        id: doi.id,
+        csv_row_number: doi.csv_row_number,
+        status: doi.status,
+        digital_object_data: doi.digital_object_data,
+        digital_object_errors: doi.digital_object_errors,
+        prerequisite_csv_row_numbers: doi.prerequisite_csv_row_numbers,
+        # requeue_count: doi.requeue_count, // not displayed in old UI
+        created_at: doi.created_at,
+        updated_at: doi.updated_at,
+        import_job_id: doi.import_job_id
+      }
+    end
+end

--- a/app/controllers/api/v2/digital_object_imports_controller.rb
+++ b/app/controllers/api/v2/digital_object_imports_controller.rb
@@ -3,8 +3,8 @@ class Api::V2::DigitalObjectImportsController < Api::V2::BaseController
   before_action :set_digital_object_import, only: [:show]
 
   # GET /api/v2/import_jobs/:import_job_id/digital_object_imports
-  # Optional query params: 
-  # - ?status=pending|success|failure 
+  # Optional query params:
+  # - ?status=pending|success|failure
   # - ?page=N
   def index
     scope = @import_job.digital_object_imports

--- a/app/controllers/api/v2/digital_object_imports_controller.rb
+++ b/app/controllers/api/v2/digital_object_imports_controller.rb
@@ -19,12 +19,15 @@ class Api::V2::DigitalObjectImportsController < Api::V2::BaseController
       digital_object_imports: @digital_object_imports.map { |doi| digital_object_import_list_json(doi) },
       pagination: pagination_data(@digital_object_imports),
       status_filter: status_filter,
+      import_job_name: @import_job.name,
     })
   end
 
   # GET /api/v2/import_jobs/:import_job_id/digital_object_imports/:id
   def show
-    render_camelized_json({ digital_object_import: digital_object_import_detail_json(@digital_object_import) })
+    render_camelized_json({
+      digital_object_import: digital_object_import_detail_json(@digital_object_import, @import_job)
+    })
   end
 
   private
@@ -61,16 +64,16 @@ class Api::V2::DigitalObjectImportsController < Api::V2::BaseController
       }
     end
 
-    def digital_object_import_detail_json(doi)
+    def digital_object_import_detail_json(doi, import_job)
       {
         id: doi.id,
         import_job_id: doi.import_job_id,
+        import_job_name: import_job.name,
         csv_row_number: doi.csv_row_number,
         status: doi.status,
         digital_object_data: doi.digital_object_data,
         digital_object_errors: doi.digital_object_errors,
         prerequisite_csv_row_numbers: doi.prerequisite_csv_row_numbers,
-        # requeue_count: doi.requeue_count, // not displayed in old UI
         created_at: doi.created_at,
         updated_at: doi.updated_at,
       }

--- a/app/controllers/api/v2/import_jobs_controller.rb
+++ b/app/controllers/api/v2/import_jobs_controller.rb
@@ -1,5 +1,5 @@
 class Api::V2::ImportJobsController < Api::V2::BaseController
-  before_action :set_import_job, only: [:show]
+  before_action :set_import_job, only: [:show, :download_original_csv]
 
   # GET /import_jobs
   def index
@@ -14,94 +14,88 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
     # end.to_h
 
     if current_user.admin?
-      puts "Admin user"
-      res = ImportJob.all.order(id: :desc).page(page).per(per_page)
-      puts res.inspect
-      @import_jobs = ImportJob.all.order(id: :desc).page(page).per(per_page)
-      render_camelized_json({ import_jobs: @import_jobs.map do |import_job|
-        import_job.user = User.find(import_job.user_id)
-        puts "Import job user: #{import_job.user.inspect}"
-        import_job_json(import_job)
-      end })
+      @import_jobs = ImportJob.includes(:user).order(id: :desc).page(page).per(per_page)
+      render_camelized_json({ import_jobs: @import_jobs.map { |import_job| import_job_json(import_job) } })
     else
-      @import_jobs = ImportJob.where(user: current_user).order(id: :desc).page(page).per(per_page)
+      @import_jobs = ImportJob.includes(:user).where(user: current_user).order(id: :desc).page(page).per(per_page)
       render_camelized_json({ import_jobs: @import_jobs.map { |import_job| import_job_json(import_job) } })
     end
   end
 
   # POST /api/v2/import_jobs
-  def create 
-    # TODO: Validate params
-    puts "In import jobs controller"
-    @import_job = build_import_job_from_upload
- 
+  def create
+    return render_missing_file_error if uploaded_csv_file.blank?
+    return render_invalid_priority_error unless valid_priority?
+
+    @import_job = Hyacinth::Utils::CsvImportExportUtils.create_import_job_from_csv_data(
+      uploaded_csv_file.read,
+      uploaded_csv_file.original_filename,
+      current_user,
+      requested_priority.to_sym
+    )
+
     if @import_job.errors.any?
       render_camelized_json({ errors: format_errors(@import_job.errors) }, status: :unprocessable_entity)
-    elsif validate_only?
-      render_camelized_json({ valid: true, message: 'The submitted CSV file appears to be valid.' })
     else
       render_camelized_json({ import_job: import_job_json(@import_job) }, status: :created)
     end
   end
 
+  # POST /api/v2/import_jobs/validate
+  def validate
+    return render_missing_file_error if uploaded_csv_file.blank?
+    return render_invalid_priority_error unless valid_priority?
+
+    import_job = ImportJob.new
+    Hyacinth::Utils::CsvImportExportUtils.validate_import_job_csv_data(
+      uploaded_csv_file.read, current_user, import_job
+    )
+    puts "Validated import job: #{import_job.inspect}"
+
+    if import_job.errors.any?
+      render_camelized_json({ valid: false, errors: format_errors(import_job.errors) }, status: :unprocessable_entity)
+    else
+      render_camelized_json({ valid: true, message: 'The submitted CSV file appears to be valid.' })
+    end
+  end
+
+  # GET /api/v2/import_jobs/:id
   def show
     # authorize! :show, @import_job
     render_camelized_json({ import_job: import_job_json(@import_job) })
   end
 
+  def download_original_csv
+    if @import_job.path_to_csv_file.present?
+      # TODO
+    end
+  end
+
   private
- 
-    def build_import_job_from_upload
-      puts "Params:"
-      puts params
-      requested_priority = params.dig(:import_job, :priority) || 'low'
-
-      # ? This mimics the logic from the old controller but is a bit weird since we create an ImportJob
-      # just to store validation errors but no job is actually created until CsvImportExportUtils.create_import_job_from_csv_data is called.
-      return import_job_with_error(:file, 'is required.') if params[:import_file].blank?
-      return import_job_with_error(:priority, "#{requested_priority} is not a valid priority.") unless valid_priority?(requested_priority)
- 
-       validate_only? ? validate_uploaded_csv : import_uploaded_csv
-    end
-
-    # Validates the uploaded CSV without queueing an import
-    def validate_uploaded_csv
-      import_job = ImportJob.new
-      Hyacinth::Utils::CsvImportExportUtils.validate_import_job_csv_data(
-        uploaded_csv_file.read, current_user, import_job
-      )
-      import_job
-    end
-
-    def import_uploaded_csv
-      Hyacinth::Utils::CsvImportExportUtils.create_import_job_from_csv_data(
-        uploaded_csv_file.read,
-        uploaded_csv_file.original_filename,
-        current_user,
-        requested_priority.to_sym
-      )
-    end
 
     def uploaded_csv_file
-      params[:import_file]
-    end
-
-    def validate_only?
-      params[:submit] == 'validate'
-    end
-
-    def valid_priority?(requested_priority)
-      requested_priority.present? && Hyacinth::Queue.const_defined?("DIGITAL_OBJECT_IMPORT_#{requested_priority.upcase}")
-    end
-
-    def import_job_with_error(attribute, message)
-      import_job = ImportJob.new
-      import_job.errors.add(attribute, message)
-      import_job
+      file = params[:import_file]
+      file.is_a?(ActionDispatch::Http::UploadedFile) ? file : nil
     end
 
     def requested_priority
       params.fetch(:priority, 'low')
+    end
+
+    def valid_priority?
+      requested_priority.present? &&
+        Hyacinth::Queue.const_defined?("DIGITAL_OBJECT_IMPORT_#{requested_priority.upcase}")
+    end
+
+    def render_missing_file_error
+      render_camelized_json({ errors: { file: ['is required.'] } }, status: :unprocessable_entity)
+    end
+
+    def render_invalid_priority_error
+      render_camelized_json(
+        { errors: { priority: ["#{requested_priority} is not a valid priority."] } },
+        status: :unprocessable_entity
+      )
     end
 
     def set_import_job
@@ -121,7 +115,11 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
         failure_count: import_job.count_failed_digital_object_imports,
         path_to_csv_file: import_job.path_to_csv_file,
         created_at: import_job.created_at,
-        updated_at: import_job.updated_at
+        updated_at: import_job.updated_at,
+        user: {
+          email: import_job.user.email,
+          full_name: "#{import_job.user.first_name} #{import_job.user.last_name}".strip
+        }
       }
     end
 end

--- a/app/controllers/api/v2/import_jobs_controller.rb
+++ b/app/controllers/api/v2/import_jobs_controller.rb
@@ -1,6 +1,37 @@
 class Api::V2::ImportJobsController < Api::V2::BaseController
+  before_action :set_import_job, only: [:show]
+
+  # GET /import_jobs
+  def index
+    page = params[:page]
+    per_page = 20
+
+    # @import_job_queue_counts = [:low, :medium, :high].map do |priority|
+    #   [
+    #     priority,
+    #     DigitalObjectImport.joins(:import_job).where(status: :pending, import_jobs: { priority: priority }).count
+    #   ]
+    # end.to_h
+
+    if current_user.admin?
+      puts "Admin user"
+      res = ImportJob.all.order(id: :desc).page(page).per(per_page)
+      puts res.inspect
+      @import_jobs = ImportJob.all.order(id: :desc).page(page).per(per_page)
+      render_camelized_json({ import_jobs: @import_jobs.map do |import_job|
+        import_job.user = User.find(import_job.user_id)
+        puts "Import job user: #{import_job.user.inspect}"
+        import_job_json(import_job)
+      end })
+    else
+      @import_jobs = ImportJob.where(user: current_user).order(id: :desc).page(page).per(per_page)
+      render_camelized_json({ import_jobs: @import_jobs.map { |import_job| import_job_json(import_job) } })
+    end
+  end
+
   # POST /api/v2/import_jobs
   def create 
+    # TODO: Validate params
     puts "In import jobs controller"
     @import_job = build_import_job_from_upload
  
@@ -12,7 +43,12 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
       render_camelized_json({ import_job: import_job_json(@import_job) }, status: :created)
     end
   end
- 
+
+  def show
+    # authorize! :show, @import_job
+    render_camelized_json({ import_job: import_job_json(@import_job) })
+  end
+
   private
  
     def build_import_job_from_upload
@@ -66,6 +102,12 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
 
     def requested_priority
       params.fetch(:priority, 'low')
+    end
+
+    def set_import_job
+      puts "Params:"
+      puts params
+      @import_job = ImportJob.find(params[:id])
     end
 
     def import_job_json(import_job)

--- a/app/controllers/api/v2/import_jobs_controller.rb
+++ b/app/controllers/api/v2/import_jobs_controller.rb
@@ -13,7 +13,7 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
       .per(per_page)
 
     render_camelized_json({
-      import_jobs: @import_jobs.map { |import_job| import_job_json(import_job) },
+      import_jobs: @import_jobs.map { |import_job| import_job_list_json(import_job) },
       pagination: pagination_data(@import_jobs)
     })
   end
@@ -46,7 +46,6 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
     Hyacinth::Utils::CsvImportExportUtils.validate_import_job_csv_data(
       uploaded_csv_file.read, current_user, import_job
     )
-    puts "Validated import job: #{import_job.inspect}"
 
     if import_job.errors.any?
       render_camelized_json({ valid: false, errors: format_errors(import_job.errors) }, status: :unprocessable_entity)
@@ -58,12 +57,11 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
   # GET /api/v2/import_jobs/:id
   def show
     # authorize! :show, @import_job
-    render_camelized_json({ import_job: import_job_json(@import_job) })
+    render_camelized_json({ import_job: import_job_detail_json(@import_job) })
   end
 
   # GET /api/v2/import_jobs/queue_activity
   def queue_activity
-    puts "In queue_activity action"
     counts = [:low, :medium, :high].map do |priority|
       [
         priority,
@@ -120,17 +118,29 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
     end
 
     def pagination_data(scope)
-    {
-      current_page: scope.current_page,
-      per_page: scope.limit_value,
-      total_pages: scope.total_pages,
-      total_count: scope.total_count
-    }
+      {
+        current_page: scope.current_page,
+        per_page: scope.limit_value,
+        total_pages: scope.total_pages,
+        total_count: scope.total_count
+      }
     end
 
-    # TODO: Import jobs displayed in the UI don't need success/pending/failure coounts. Create a separate json response for index action 
-    # that doesn't include those counts
-    def import_job_json(import_job)
+    def import_job_list_json(import_job)
+      {
+        id: import_job.id,
+        name: import_job.name,
+        priority: import_job.priority,
+        status: import_job.status_string,
+        created_at: import_job.created_at,
+        user: {
+          email: import_job.user.email,
+          full_name: "#{import_job.user.first_name} #{import_job.user.last_name}".strip
+        }
+      }
+    end
+
+    def import_job_detail_json(import_job)
       {
         id: import_job.id,
         name: import_job.name,

--- a/app/controllers/api/v2/import_jobs_controller.rb
+++ b/app/controllers/api/v2/import_jobs_controller.rb
@@ -1,17 +1,10 @@
 class Api::V2::ImportJobsController < Api::V2::BaseController
-  before_action :set_import_job, only: [:show, :download_original_csv]
+  before_action :set_import_job, only: [:show, :download_original_csv, :destroy]
 
   # GET /import_jobs
   def index
     page = params[:page]
     per_page = 20
-
-    # @import_job_queue_counts = [:low, :medium, :high].map do |priority|
-    #   [
-    #     priority,
-    #     DigitalObjectImport.joins(:import_job).where(status: :pending, import_jobs: { priority: priority }).count
-    #   ]
-    # end.to_h
 
     if current_user.admin?
       @import_jobs = ImportJob.includes(:user).order(id: :desc).page(page).per(per_page)
@@ -65,10 +58,31 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
     render_camelized_json({ import_job: import_job_json(@import_job) })
   end
 
+  # GET /api/v2/import_jobs/queue_activity
+  def queue_activity
+    puts "In queue_activity action"
+    counts = [:low, :medium, :high].map do |priority|
+      [
+        priority,
+        DigitalObjectImport
+          .joins(:import_job)
+          .where(status: :pending, import_jobs: { priority: priority })
+          .count
+      ]
+    end.to_h
+
+    render_camelized_json({ queue_activity: counts })
+  end
+
   def download_original_csv
     if @import_job.path_to_csv_file.present?
       # TODO
     end
+  end
+
+  # DELETE /api/v2/import_jobs/:id
+  def destroy
+    @import_job.destroy
   end
 
   private
@@ -99,8 +113,6 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
     end
 
     def set_import_job
-      puts "Params:"
-      puts params
       @import_job = ImportJob.find(params[:id])
     end
 

--- a/app/controllers/api/v2/import_jobs_controller.rb
+++ b/app/controllers/api/v2/import_jobs_controller.rb
@@ -4,7 +4,7 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
   # GET /import_jobs
   def index
     authorize! :index, ImportJob
-    per_page = 5 # temp
+    per_page = 20
 
     # CanCanCan already filters the import jobs based on the current user's permissions
     @import_jobs = ImportJob.accessible_by(current_ability)

--- a/app/controllers/api/v2/import_jobs_controller.rb
+++ b/app/controllers/api/v2/import_jobs_controller.rb
@@ -134,6 +134,7 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
         status: import_job.status_string,
         created_at: import_job.created_at,
         user: {
+          uid: import_job.user.uid,
           email: import_job.user.email,
           full_name: "#{import_job.user.first_name} #{import_job.user.last_name}".strip
         }
@@ -153,8 +154,9 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
         created_at: import_job.created_at,
         updated_at: import_job.updated_at,
         user: {
+          uid: import_job.user.uid,
           email: import_job.user.email,
-          full_name: "#{import_job.user.first_name} #{import_job.user.last_name}".strip
+          full_name: "#{import_job.user.first_name} #{import_job.user.last_name}".strip,
         }
       }
     end

--- a/app/controllers/api/v2/import_jobs_controller.rb
+++ b/app/controllers/api/v2/import_jobs_controller.rb
@@ -1,5 +1,5 @@
 class Api::V2::ImportJobsController < Api::V2::BaseController
-  before_action :set_import_job, only: [:show, :download_original_csv, :destroy]
+  before_action :set_import_job, only: [:show, :download_original_csv, :download_csv_without_successful_rows, :destroy]
 
   # GET /import_jobs
   def index
@@ -79,11 +79,43 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
     render_camelized_json({ queue_activity: counts })
   end
 
+  # GET /api/v2/import_jobs/:id/download_original_csv
   def download_original_csv
     authorize! :show, @import_job
+
     if @import_job.path_to_csv_file.present?
-      # TODO
+      send_file @import_job.path_to_csv_file, filename: File.basename(@import_job.name)
+    else
+      render_camelized_json({ errors: { file: ['No CSV file available for this import job.'] } }, status: :not_found)
     end
+  end
+
+  # GET /api/v2/import_jobs/:id/download_csv_without_successful_rows
+  def download_csv_without_successful_rows
+    authorize! :show, @import_job
+
+    return render_camelized_json(
+      { errors: { file: ['No CSV file available for this import job.'] } },
+      status: :not_found
+    ) if @import_job.path_to_csv_file.blank?
+
+    csv_rows_to_collect = @import_job.csv_row_numbers_for_all_non_successful_digital_object_imports.to_set
+    csv_data_string = ''
+    csv_row_counter = 1
+    found_header_row = false
+
+    CSV.foreach(@import_job.path_to_csv_file) do |row|
+      if !found_header_row
+        csv_data_string << CSV.generate_line(row)
+        found_header_row = true if row[0].start_with?('_')
+      elsif csv_rows_to_collect.include?(csv_row_counter)
+        csv_data_string << CSV.generate_line(row)
+      end
+
+      csv_row_counter += 1
+    end
+
+    send_data(csv_data_string, type: 'text/csv', filename: "without-successful-rows-#{File.basename(@import_job.name)}")
   end
 
   # DELETE /api/v2/import_jobs/:id

--- a/app/controllers/api/v2/import_jobs_controller.rb
+++ b/app/controllers/api/v2/import_jobs_controller.rb
@@ -3,10 +3,11 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
 
   # GET /import_jobs
   def index
-    scope = current_user.admin? ? ImportJob.all : ImportJob.where(user: current_user)
+    authorize! :index, ImportJob
     per_page = 5 # temp
 
-    @import_jobs = scope
+    # CanCanCan already filters the import jobs based on the current user's permissions
+    @import_jobs = ImportJob.accessible_by(current_ability)
       .includes(:user)
       .order(id: :desc)
       .page(params[:page])
@@ -59,7 +60,7 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
 
   # GET /api/v2/import_jobs/:id
   def show
-    # authorize! :show, @import_job
+    authorize! :show, @import_job
     render_camelized_json({ import_job: import_job_detail_json(@import_job) })
   end
 
@@ -79,6 +80,7 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
   end
 
   def download_original_csv
+    authorize! :show, @import_job
     if @import_job.path_to_csv_file.present?
       # TODO
     end
@@ -86,6 +88,7 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
 
   # DELETE /api/v2/import_jobs/:id
   def destroy
+    authorize! :destroy, @import_job
     @import_job.destroy
   end
 
@@ -135,6 +138,7 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
         name: import_job.name,
         priority: import_job.priority,
         status: import_job.status_string,
+        complete: import_job.complete?,
         created_at: import_job.created_at,
         user: {
           uid: import_job.user.uid,

--- a/app/controllers/api/v2/import_jobs_controller.rb
+++ b/app/controllers/api/v2/import_jobs_controller.rb
@@ -1,0 +1,85 @@
+class Api::V2::ImportJobsController < Api::V2::BaseController
+  # POST /api/v2/import_jobs
+  def create 
+    puts "In import jobs controller"
+    @import_job = build_import_job_from_upload
+ 
+    if @import_job.errors.any?
+      render_camelized_json({ errors: format_errors(@import_job.errors) }, status: :unprocessable_entity)
+    elsif validate_only?
+      render_camelized_json({ valid: true, message: 'The submitted CSV file appears to be valid.' })
+    else
+      render_camelized_json({ import_job: import_job_json(@import_job) }, status: :created)
+    end
+  end
+ 
+  private
+ 
+    def build_import_job_from_upload
+      puts "Params:"
+      puts params
+      requested_priority = params.dig(:import_job, :priority) || 'low'
+
+      # ? This mimics the logic from the old controller but is a bit weird since we create an ImportJob
+      # just to store validation errors but no job is actually created until CsvImportExportUtils.create_import_job_from_csv_data is called.
+      return import_job_with_error(:file, 'is required.') if params[:import_file].blank?
+      return import_job_with_error(:priority, "#{requested_priority} is not a valid priority.") unless valid_priority?(requested_priority)
+ 
+       validate_only? ? validate_uploaded_csv : import_uploaded_csv
+    end
+
+    # Validates the uploaded CSV without queueing an import
+    def validate_uploaded_csv
+      import_job = ImportJob.new
+      Hyacinth::Utils::CsvImportExportUtils.validate_import_job_csv_data(
+        uploaded_csv_file.read, current_user, import_job
+      )
+      import_job
+    end
+
+    def import_uploaded_csv
+      Hyacinth::Utils::CsvImportExportUtils.create_import_job_from_csv_data(
+        uploaded_csv_file.read,
+        uploaded_csv_file.original_filename,
+        current_user,
+        requested_priority.to_sym
+      )
+    end
+
+    def uploaded_csv_file
+      params[:import_file]
+    end
+
+    def validate_only?
+      params[:submit] == 'validate'
+    end
+
+    def valid_priority?(requested_priority)
+      requested_priority.present? && Hyacinth::Queue.const_defined?("DIGITAL_OBJECT_IMPORT_#{requested_priority.upcase}")
+    end
+
+    def import_job_with_error(attribute, message)
+      import_job = ImportJob.new
+      import_job.errors.add(attribute, message)
+      import_job
+    end
+
+    def requested_priority
+      params.fetch(:priority, 'low')
+    end
+
+    def import_job_json(import_job)
+      {
+        id: import_job.id,
+        name: import_job.name,
+        priority: import_job.priority,
+        status: import_job.status_string,
+        pending_count: import_job.count_pending_digital_object_imports,
+        success_count: import_job.count_successful_digital_object_imports,
+        failure_count: import_job.count_failed_digital_object_imports,
+        path_to_csv_file: import_job.path_to_csv_file,
+        created_at: import_job.created_at,
+        updated_at: import_job.updated_at
+      }
+    end
+end

--- a/app/controllers/api/v2/import_jobs_controller.rb
+++ b/app/controllers/api/v2/import_jobs_controller.rb
@@ -3,16 +3,19 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
 
   # GET /import_jobs
   def index
-    page = params[:page]
-    per_page = 20
+    scope = current_user.admin? ? ImportJob.all : ImportJob.where(user: current_user)
+    per_page = 5 # temp
 
-    if current_user.admin?
-      @import_jobs = ImportJob.includes(:user).order(id: :desc).page(page).per(per_page)
-      render_camelized_json({ import_jobs: @import_jobs.map { |import_job| import_job_json(import_job) } })
-    else
-      @import_jobs = ImportJob.includes(:user).where(user: current_user).order(id: :desc).page(page).per(per_page)
-      render_camelized_json({ import_jobs: @import_jobs.map { |import_job| import_job_json(import_job) } })
-    end
+    @import_jobs = scope
+      .includes(:user)
+      .order(id: :desc)
+      .page(params[:page])
+      .per(per_page)
+
+    render_camelized_json({
+      import_jobs: @import_jobs.map { |import_job| import_job_json(import_job) },
+      pagination: pagination_data(@import_jobs)
+    })
   end
 
   # POST /api/v2/import_jobs
@@ -116,6 +119,17 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
       @import_job = ImportJob.find(params[:id])
     end
 
+    def pagination_data(scope)
+    {
+      current_page: scope.current_page,
+      per_page: scope.limit_value,
+      total_pages: scope.total_pages,
+      total_count: scope.total_count
+    }
+    end
+
+    # TODO: Import jobs displayed in the UI don't need success/pending/failure coounts. Create a separate json response for index action 
+    # that doesn't include those counts
     def import_job_json(import_job)
       {
         id: import_job.id,

--- a/app/controllers/api/v2/import_jobs_controller.rb
+++ b/app/controllers/api/v2/import_jobs_controller.rb
@@ -13,7 +13,7 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
       .per(per_page)
 
     render_camelized_json({
-      import_jobs: @import_jobs.map { |import_job| import_job_list_json(import_job) },
+      import_jobs: @import_jobs.map { |import_job| import_job_summary_json(import_job) },
       pagination: pagination_data(@import_jobs)
     })
   end
@@ -23,17 +23,20 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
     return render_missing_file_error if uploaded_csv_file.blank?
     return render_invalid_priority_error unless valid_priority?
 
-    @import_job = Hyacinth::Utils::CsvImportExportUtils.create_import_job_from_csv_data(
+    args = [
       uploaded_csv_file.read,
       uploaded_csv_file.original_filename,
       current_user,
       requested_priority.to_sym
-    )
+    ]
+    args << true if params[:restore_archived_s3_objects_for_new_assets] == 'true'
+
+    @import_job = Hyacinth::Utils::CsvImportExportUtils.create_import_job_from_csv_data(*args)
 
     if @import_job.errors.any?
       render_camelized_json({ errors: format_errors(@import_job.errors) }, status: :unprocessable_entity)
     else
-      render_camelized_json({ import_job: import_job_json(@import_job) }, status: :created)
+      render_camelized_json({ import_job: import_job_summary_json(@import_job) }, status: :created)
     end
   end
 
@@ -126,7 +129,7 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
       }
     end
 
-    def import_job_list_json(import_job)
+    def import_job_summary_json(import_job)
       {
         id: import_job.id,
         name: import_job.name,
@@ -146,6 +149,7 @@ class Api::V2::ImportJobsController < Api::V2::BaseController
         id: import_job.id,
         name: import_job.name,
         priority: import_job.priority,
+        restore_archived_s3_objects_for_new_assets: import_job.restore_archived_s3_objects_for_new_assets,
         status: import_job.status_string,
         pending_count: import_job.count_pending_digital_object_imports,
         success_count: import_job.count_successful_digital_object_imports,

--- a/app/frontend/src/app/router.tsx
+++ b/app/frontend/src/app/router.tsx
@@ -38,104 +38,123 @@ const convert = (queryClient: QueryClient) => (m: RouteModule) => {
 };
 
 export const createAppRouter = (queryClient: QueryClient) =>
-  createBrowserRouter([
+  createBrowserRouter(
+    [
+      {
+        Component: MainLayout,
+        hydrateFallbackElement: <Spinner animation="border" role="status" />,
+        children: [
+          {
+            index: true,
+            Component: Root,
+          },
+          {
+            path: 'users',
+            Component: () => <FeatureLayout featureName="User" />, // Wraps all users routes with shared navigation
+            ErrorBoundary: AuthorizationErrorBoundary, // Catch authorization errors from loaders
+            children: [
+              {
+                index: true,
+                lazy: () => import('./routes/users').then(convert(queryClient)),
+              },
+              {
+                path: ':userUid',
+                Component: UserLayout,
+                children: [
+                  {
+                    path: 'edit', // maybe this should be the default (index) route under :userUid
+                    lazy: () => import('./routes/users/edit').then(convert(queryClient)),
+                  },
+                  {
+                    path: 'project-permissions/edit',
+                    lazy: () =>
+                      import('./routes/users/project-permissions').then(convert(queryClient)),
+                  },
+                ],
+              },
+              {
+                path: 'new',
+                lazy: () => import('./routes/users/new').then(convert(queryClient)),
+              },
+            ],
+          },
+          {
+            path: 'publish-targets',
+            Component: () => <FeatureLayout featureName="Publish Target" />, // Wraps all publish targets routes with shared navigation
+            ErrorBoundary: AuthorizationErrorBoundary, // Catch authorization errors from loaders
+            children: [
+              {
+                index: true,
+                lazy: () => import('./routes/publish-targets').then(convert(queryClient)),
+              },
+              {
+                path: ':publishTargetStringKey/edit',
+                lazy: () => import('./routes/publish-targets/edit').then(convert(queryClient)),
+              },
+              {
+                path: 'new',
+                lazy: () => import('./routes/publish-targets/new').then(convert(queryClient)),
+              },
+            ],
+          },
+          {
+            path: 'xml-datastreams',
+            ErrorBoundary: AuthorizationErrorBoundary, // Catch authorization errors from loaders
+            Component: () => <FeatureLayout featureName="XML Datastream" />,
+            children: [
+              {
+                index: true,
+                lazy: () => import('./routes/xml-datastreams').then(convert(queryClient)),
+              },
+              {
+                path: ':xmlDatastreamStringKey/edit',
+                lazy: () => import('./routes/xml-datastreams/edit').then(convert(queryClient)),
+              },
+              {
+                path: 'new',
+                lazy: () => import('./routes/xml-datastreams/new').then(convert(queryClient)),
+              },
+            ],
+          },
+          {
+            path: 'import-jobs',
+            Component: () => <FeatureLayout featureName="Import Job" />,
+            children: [
+              {
+                index: true,
+                lazy: () => import('./routes/import-jobs').then(convert(queryClient)),
+              },
+              {
+                path: 'new',
+                lazy: () => import('./routes/import-jobs/new').then(convert(queryClient)),
+              },
+            ],
+          },
+          {
+            path: 'settings',
+            children: [
+              {
+                index: true,
+                lazy: () => import('./routes/settings').then(convert(queryClient)),
+              },
+              {
+                path: 'project-permissions',
+                lazy: () =>
+                  import('./routes/settings/project-permissions').then(convert(queryClient)),
+              },
+            ],
+          },
+        ],
+      },
+      {
+        path: '*',
+        lazy: () => import('./routes/not-found').then(convert(queryClient)),
+      },
+    ],
     {
-      Component: MainLayout,
-      hydrateFallbackElement: <Spinner animation="border" role="status" />,
-      children: [
-        {
-          index: true,
-          Component: Root,
-        },
-        {
-          path: 'users',
-          Component: () => <FeatureLayout featureName="User"/>, // Wraps all users routes with shared navigation
-          ErrorBoundary: AuthorizationErrorBoundary, // Catch authorization errors from loaders
-          children: [
-            {
-              index: true,
-              lazy: () => import('./routes/users').then(convert(queryClient)),
-            },
-            {
-              path: ':userUid',
-              Component: UserLayout,
-              children: [
-                {
-                  path: 'edit', // maybe this should be the default (index) route under :userUid
-                  lazy: () => import('./routes/users/edit').then(convert(queryClient)),
-                },
-                {
-                  path: 'project-permissions/edit',
-                  lazy: () => import('./routes/users/project-permissions').then(convert(queryClient)),
-                },
-              ]
-            },
-            {
-              path: 'new',
-              lazy: () => import('./routes/users/new').then(convert(queryClient)),
-            },
-          ]
-        },
-        {
-          path: 'publish-targets',
-          Component: () => <FeatureLayout featureName="Publish Target" />, // Wraps all publish targets routes with shared navigation
-          ErrorBoundary: AuthorizationErrorBoundary, // Catch authorization errors from loaders
-           children: [
-            {
-              index: true,
-              lazy: () => import('./routes/publish-targets').then(convert(queryClient)),
-            },
-            {
-              path: ':publishTargetStringKey/edit',
-              lazy: () => import('./routes/publish-targets/edit').then(convert(queryClient)),
-            },
-            {
-              path: 'new',
-              lazy: () => import('./routes/publish-targets/new').then(convert(queryClient)),
-            },
-          ]
-        },
-        {
-          path: 'xml-datastreams',
-          ErrorBoundary: AuthorizationErrorBoundary, // Catch authorization errors from loaders
-          Component: () => <FeatureLayout featureName="XML Datastream" />,
-          children: [
-            {
-              index: true,
-              lazy: () => import('./routes/xml-datastreams').then(convert(queryClient)),
-            },
-            {
-              path: ':xmlDatastreamStringKey/edit',
-              lazy: () => import('./routes/xml-datastreams/edit').then(convert(queryClient)),
-            },
-            {
-              path: 'new',
-              lazy: () => import('./routes/xml-datastreams/new').then(convert(queryClient)),
-            }
-          ],
-        },
-        {
-          path: 'settings',
-          children: [
-            {
-              index: true,
-              lazy: () => import('./routes/settings').then(convert(queryClient))
-            },
-            {
-              path: 'project-permissions',
-              lazy: () => import('./routes/settings/project-permissions').then(convert(queryClient))
-            },
-          ]
-        }
-      ],
+      basename: '/ui/v2',
     },
-    {
-      path: '*',
-      lazy: () => import('./routes/not-found').then(convert(queryClient)),
-    },
-  ], {
-    basename: '/ui/v2',
-  });
+  );
 
 export const AppRouter = () => {
   const queryClient = useQueryClient();

--- a/app/frontend/src/app/router.tsx
+++ b/app/frontend/src/app/router.tsx
@@ -118,6 +118,7 @@ export const createAppRouter = (queryClient: QueryClient) =>
           },
           {
             path: 'import-jobs',
+            ErrorBoundary: AuthorizationErrorBoundary, // Catch authorization errors from loaders
             children: [
               {
                 Component: () => <FeatureLayout featureName="Import Job" />,

--- a/app/frontend/src/app/router.tsx
+++ b/app/frontend/src/app/router.tsx
@@ -134,6 +134,13 @@ export const createAppRouter = (queryClient: QueryClient) =>
                   import('./routes/import-jobs/digital-object-imports').then(convert(queryClient)),
               },
               {
+                path: ':importJobId/digital-object-imports/:digitalObjectImportId',
+                lazy: () =>
+                  import('./routes/import-jobs/digital-object-imports/view').then(
+                    convert(queryClient),
+                  ),
+              },
+              {
                 path: 'new',
                 lazy: () => import('./routes/import-jobs/new').then(convert(queryClient)),
               },

--- a/app/frontend/src/app/router.tsx
+++ b/app/frontend/src/app/router.tsx
@@ -118,15 +118,23 @@ export const createAppRouter = (queryClient: QueryClient) =>
           },
           {
             path: 'import-jobs',
-            Component: () => <FeatureLayout featureName="Import Job" />,
             children: [
               {
-                index: true,
-                lazy: () => import('./routes/import-jobs').then(convert(queryClient)),
-              },
-              {
-                path: ':importJobId',
-                lazy: () => import('./routes/import-jobs/view').then(convert(queryClient)),
+                Component: () => <FeatureLayout featureName="Import Job" />,
+                children: [
+                  {
+                    index: true,
+                    lazy: () => import('./routes/import-jobs').then(convert(queryClient)),
+                  },
+                  {
+                    path: ':importJobId',
+                    lazy: () => import('./routes/import-jobs/view').then(convert(queryClient)),
+                  },
+                  {
+                    path: 'new',
+                    lazy: () => import('./routes/import-jobs/new').then(convert(queryClient)),
+                  },
+                ],
               },
               {
                 path: ':importJobId/digital-object-imports',
@@ -139,10 +147,6 @@ export const createAppRouter = (queryClient: QueryClient) =>
                   import('./routes/import-jobs/digital-object-imports/view').then(
                     convert(queryClient),
                   ),
-              },
-              {
-                path: 'new',
-                lazy: () => import('./routes/import-jobs/new').then(convert(queryClient)),
               },
             ],
           },

--- a/app/frontend/src/app/router.tsx
+++ b/app/frontend/src/app/router.tsx
@@ -129,6 +129,11 @@ export const createAppRouter = (queryClient: QueryClient) =>
                 lazy: () => import('./routes/import-jobs/view').then(convert(queryClient)),
               },
               {
+                path: ':importJobId/digital-object-imports',
+                lazy: () =>
+                  import('./routes/import-jobs/digital-object-imports').then(convert(queryClient)),
+              },
+              {
                 path: 'new',
                 lazy: () => import('./routes/import-jobs/new').then(convert(queryClient)),
               },

--- a/app/frontend/src/app/router.tsx
+++ b/app/frontend/src/app/router.tsx
@@ -125,6 +125,10 @@ export const createAppRouter = (queryClient: QueryClient) =>
                 lazy: () => import('./routes/import-jobs').then(convert(queryClient)),
               },
               {
+                path: ':importJobId',
+                lazy: () => import('./routes/import-jobs/view').then(convert(queryClient)),
+              },
+              {
                 path: 'new',
                 lazy: () => import('./routes/import-jobs/new').then(convert(queryClient)),
               },

--- a/app/frontend/src/app/routes/import-jobs/digital-object-imports/index.tsx
+++ b/app/frontend/src/app/routes/import-jobs/digital-object-imports/index.tsx
@@ -1,12 +1,12 @@
 import { Suspense } from 'react';
 import { QueryClient } from '@tanstack/react-query';
-import { useParams } from 'react-router';
+import { useParams, LoaderFunctionArgs } from 'react-router';
 import { getDigitalObjectImportsQueryOptions } from '@/features/digital-object-imports/api/get-digital-object-imports';
 import { DigitalObjectImportsList } from '@/features/digital-object-imports/components/digital-object-imports-list';
 
 export const clientLoader =
   (queryClient: QueryClient) =>
-  async ({ params, request }: any) => {
+  async ({ params, request }: LoaderFunctionArgs) => {
     const importJobId = params.importJobId as string;
     const url = new URL(request.url);
     const page = Number(url.searchParams.get('page')) || 1;

--- a/app/frontend/src/app/routes/import-jobs/digital-object-imports/index.tsx
+++ b/app/frontend/src/app/routes/import-jobs/digital-object-imports/index.tsx
@@ -1,0 +1,31 @@
+import { Suspense } from 'react';
+import { QueryClient } from '@tanstack/react-query';
+import { useParams } from 'react-router';
+import { getDigitalObjectImportsQueryOptions } from '@/features/digital-object-imports/api/get-digital-object-imports';
+import { DigitalObjectImportsList } from '@/features/digital-object-imports/components/digital-object-imports-list';
+
+export const clientLoader =
+  (queryClient: QueryClient) =>
+  async ({ params, request }: any) => {
+    const importJobId = params.importJobId as string;
+    const url = new URL(request.url);
+    const page = Number(url.searchParams.get('page')) || 1;
+    const status = url.searchParams.get('status') ?? undefined;
+
+    await queryClient.ensureQueryData(
+      getDigitalObjectImportsQueryOptions({ importJobId, page, status }),
+    );
+  };
+
+const DigitalObjectImportsRoute = () => {
+  const params = useParams();
+  const importJobId = params.importJobId as string;
+
+  return (
+    <Suspense fallback={<p className="text-muted">Loading imports...</p>}>
+      <DigitalObjectImportsList importJobId={importJobId} />
+    </Suspense>
+  );
+};
+
+export default DigitalObjectImportsRoute;

--- a/app/frontend/src/app/routes/import-jobs/digital-object-imports/view.tsx
+++ b/app/frontend/src/app/routes/import-jobs/digital-object-imports/view.tsx
@@ -1,5 +1,5 @@
 import { QueryClient } from '@tanstack/react-query';
-import { useParams } from 'react-router';
+import { useParams, LoaderFunctionArgs } from 'react-router';
 import {
   getDigitalObjectImportQueryOptions,
   useDigitalObjectImportSuspenseQuery,
@@ -8,7 +8,7 @@ import { DigitalObjectDetail } from '@/features/digital-object-imports/component
 
 export const clientLoader =
   (queryClient: QueryClient) =>
-  async ({ params }: any) => {
+  async ({ params }: LoaderFunctionArgs) => {
     const importJobId = params.importJobId as string;
     const digitalObjectImportId = params.digitalObjectImportId as string;
 

--- a/app/frontend/src/app/routes/import-jobs/digital-object-imports/view.tsx
+++ b/app/frontend/src/app/routes/import-jobs/digital-object-imports/view.tsx
@@ -1,0 +1,29 @@
+import { QueryClient } from '@tanstack/react-query';
+// import { ImportJobDetail } from '@/features/import-jobs/components/import-job-detail';
+import {
+  getDigitalObjectImportQueryOptions,
+  useDigitalObjectImportSuspenseQuery,
+} from '@/features/digital-object-imports/api/get-digital-object-import';
+import { useParams } from 'react-router';
+
+export const clientLoader =
+  (queryClient: QueryClient) =>
+  async ({ params, request }: any) => {
+    const importJobId = params.importJobId as string;
+    const digitalObjectImportId = params.digitalObjectImportId as string;
+    await queryClient.ensureQueryData(
+      getDigitalObjectImportQueryOptions({ importJobId, digitalObjectImportId }),
+    );
+  };
+
+const DigitalObjectImportsViewRoute = () => {
+  const params = useParams();
+  const importJobId = params.importJobId as string;
+  const digitalObjectImportId = params.digitalObjectImportId as string;
+
+  const data = useDigitalObjectImportSuspenseQuery({ importJobId, digitalObjectImportId });
+  console.log('data', data);
+  return <div>Hii</div>;
+};
+
+export default DigitalObjectImportsViewRoute;

--- a/app/frontend/src/app/routes/import-jobs/digital-object-imports/view.tsx
+++ b/app/frontend/src/app/routes/import-jobs/digital-object-imports/view.tsx
@@ -1,16 +1,17 @@
 import { QueryClient } from '@tanstack/react-query';
-// import { ImportJobDetail } from '@/features/import-jobs/components/import-job-detail';
+import { useParams } from 'react-router';
 import {
   getDigitalObjectImportQueryOptions,
   useDigitalObjectImportSuspenseQuery,
 } from '@/features/digital-object-imports/api/get-digital-object-import';
-import { useParams } from 'react-router';
+import { DigitalObjectDetail } from '@/features/digital-object-imports/components/digital-object-detail';
 
 export const clientLoader =
   (queryClient: QueryClient) =>
-  async ({ params, request }: any) => {
+  async ({ params }: any) => {
     const importJobId = params.importJobId as string;
     const digitalObjectImportId = params.digitalObjectImportId as string;
+
     await queryClient.ensureQueryData(
       getDigitalObjectImportQueryOptions({ importJobId, digitalObjectImportId }),
     );
@@ -21,9 +22,9 @@ const DigitalObjectImportsViewRoute = () => {
   const importJobId = params.importJobId as string;
   const digitalObjectImportId = params.digitalObjectImportId as string;
 
-  const data = useDigitalObjectImportSuspenseQuery({ importJobId, digitalObjectImportId });
-  console.log('data', data);
-  return <div>Hii</div>;
+  const { data } = useDigitalObjectImportSuspenseQuery({ importJobId, digitalObjectImportId });
+
+  return <DigitalObjectDetail digitalObjectImport={data.digitalObjectImport} />;
 };
 
 export default DigitalObjectImportsViewRoute;

--- a/app/frontend/src/app/routes/import-jobs/index.tsx
+++ b/app/frontend/src/app/routes/import-jobs/index.tsx
@@ -1,5 +1,14 @@
+import { QueryClient } from '@tanstack/react-query';
+import ImportJobsList from '@/features/import-jobs/components/import-jobs-list';
+import { getImportJobsQueryOptions } from '@/features/import-jobs/api/get-import-jobs';
+
+export const clientLoader = (queryClient: QueryClient) => async () => {
+  const query = getImportJobsQueryOptions();
+  return await queryClient.ensureQueryData(query);
+};
+
 const ImportJobsIndexRoute = () => {
-  return <div>Import job list</div>;
+  return <ImportJobsList />;
 };
 
 export default ImportJobsIndexRoute;

--- a/app/frontend/src/app/routes/import-jobs/index.tsx
+++ b/app/frontend/src/app/routes/import-jobs/index.tsx
@@ -1,6 +1,8 @@
+import { Suspense } from 'react';
 import { QueryClient } from '@tanstack/react-query';
-import ImportJobsList from '@/features/import-jobs/components/import-jobs-list';
 import { getImportJobsQueryOptions } from '@/features/import-jobs/api/get-import-jobs';
+import { QueueActivityDisplay } from '@/features/import-jobs/components/queue-activity-display';
+import ImportJobsList from '@/features/import-jobs/components/import-jobs-list';
 
 export const clientLoader = (queryClient: QueryClient) => async () => {
   const query = getImportJobsQueryOptions();
@@ -8,7 +10,15 @@ export const clientLoader = (queryClient: QueryClient) => async () => {
 };
 
 const ImportJobsIndexRoute = () => {
-  return <ImportJobsList />;
+  return (
+    <>
+      <Suspense fallback={<p className="text-muted">Loading activity...</p>}>
+        <QueueActivityDisplay />
+      </Suspense>
+
+      <ImportJobsList />
+    </>
+  );
 };
 
 export default ImportJobsIndexRoute;

--- a/app/frontend/src/app/routes/import-jobs/index.tsx
+++ b/app/frontend/src/app/routes/import-jobs/index.tsx
@@ -1,0 +1,5 @@
+const ImportJobsIndexRoute = () => {
+  return <div>Import job list</div>;
+};
+
+export default ImportJobsIndexRoute;

--- a/app/frontend/src/app/routes/import-jobs/index.tsx
+++ b/app/frontend/src/app/routes/import-jobs/index.tsx
@@ -4,7 +4,7 @@ import { getImportJobsQueryOptions } from '@/features/import-jobs/api/get-import
 
 export const clientLoader = (queryClient: QueryClient) => async () => {
   const query = getImportJobsQueryOptions();
-  return await queryClient.ensureQueryData(query);
+  await queryClient.ensureQueryData(query);
 };
 
 const ImportJobsIndexRoute = () => {

--- a/app/frontend/src/app/routes/import-jobs/index.tsx
+++ b/app/frontend/src/app/routes/import-jobs/index.tsx
@@ -4,10 +4,12 @@ import { getImportJobsQueryOptions } from '@/features/import-jobs/api/get-import
 import { QueueActivityDisplay } from '@/features/import-jobs/components/queue-activity-display';
 import ImportJobsList from '@/features/import-jobs/components/import-jobs-list';
 
-export const clientLoader = (queryClient: QueryClient) => async () => {
-  const query = getImportJobsQueryOptions();
-  await queryClient.ensureQueryData(query);
-};
+export const clientLoader =
+  (queryClient: QueryClient) =>
+  async ({ request }: any) => {
+    const page = Number(new URL(request.url).searchParams.get('page')) || 1;
+    await queryClient.ensureQueryData(getImportJobsQueryOptions(page));
+  };
 
 const ImportJobsIndexRoute = () => {
   return (

--- a/app/frontend/src/app/routes/import-jobs/new.tsx
+++ b/app/frontend/src/app/routes/import-jobs/new.tsx
@@ -1,9 +1,16 @@
 import { ImportJobForm } from '@/features/import-jobs/components/import-job-form';
+import { Alert } from 'react-bootstrap';
 
 const ImportJobsNewRoute = () => {
   return (
     <div>
-      <ImportJobForm />
+      <Alert variant="info">
+        Important Note: Please avoid using Microsoft Excel for CSV editing, imports, or exports.
+        Excel doesn't handle UTF-8 properly.
+      </Alert>
+      <div className="pt-2">
+        <ImportJobForm />
+      </div>
     </div>
   );
 };

--- a/app/frontend/src/app/routes/import-jobs/new.tsx
+++ b/app/frontend/src/app/routes/import-jobs/new.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import { Button, Col, Form, Row } from 'react-bootstrap';
+import { Input, Select } from '@/components/ui/form';
+import { useCreateImportJob } from '@/features/import-jobs/api/create-import-job';
+
+const ImportJobsNewRoute = () => {
+  const [formData, setFormData] = useState<{
+    file: File | null;
+    priority: string;
+  }>({
+    file: null,
+    priority: 'low',
+  });
+
+  const createJobImportMutation = useCreateImportJob({
+    mutationConfig: {
+      onSuccess: (data) => {
+        // TODO: navigate to the new import job's page
+      },
+    },
+  });
+
+  // const fieldErrors: Record<string, string> = {};
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    console.log('Submitting values', formData);
+    if (formData.file) {
+      createJobImportMutation.mutate({
+        data: { file: formData.file, priority: formData.priority },
+      });
+    }
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] ?? null;
+    setFormData((prev) => ({ ...prev, file }));
+  };
+
+  const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  return (
+    <div>
+      <Form onSubmit={handleSubmit} className="mb-8">
+        <Row className="mb-3">
+          <Input
+            label="File"
+            type="file"
+            onChange={handleFileChange}
+            // error={fieldErrors.file}
+            name="file"
+            md={7}
+            required
+          />
+        </Row>
+        <Row className="mb-3">
+          <Select
+            label="Priority"
+            name="priority"
+            value={formData.priority}
+            onChange={handleSelectChange}
+            md={7}
+            // error={fieldErrors.priority}
+          >
+            <option value="low">Low</option>
+            <option value="medium">Medium</option>
+            <option value="high">High</option>
+          </Select>
+        </Row>
+
+        {/* TODO: Ability to validate job import without uploading */}
+        <Row className="mb-4 mt-2">
+          <Col md={7}>
+            <Button
+              variant="primary"
+              type="submit"
+              disabled={createJobImportMutation.isPending}
+              className="px-3"
+            >
+              {createJobImportMutation.isPending ? 'Saving...' : 'Create a New Import Job'}
+            </Button>
+          </Col>
+        </Row>
+      </Form>
+    </div>
+  );
+};
+
+export default ImportJobsNewRoute;

--- a/app/frontend/src/app/routes/import-jobs/new.tsx
+++ b/app/frontend/src/app/routes/import-jobs/new.tsx
@@ -1,91 +1,9 @@
-import { useState } from 'react';
-import { Button, Col, Form, Row } from 'react-bootstrap';
-import { Input, Select } from '@/components/ui/form';
-import { useCreateImportJob } from '@/features/import-jobs/api/create-import-job';
+import { ImportJobForm } from '@/features/import-jobs/components/import-job-form';
 
 const ImportJobsNewRoute = () => {
-  const [formData, setFormData] = useState<{
-    file: File | null;
-    priority: string;
-  }>({
-    file: null,
-    priority: 'low',
-  });
-
-  const createJobImportMutation = useCreateImportJob({
-    mutationConfig: {
-      onSuccess: (data) => {
-        // TODO: navigate to the new import job's page
-      },
-    },
-  });
-
-  // const fieldErrors: Record<string, string> = {};
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-
-    console.log('Submitting values', formData);
-    if (formData.file) {
-      createJobImportMutation.mutate({
-        data: { file: formData.file, priority: formData.priority },
-      });
-    }
-  };
-
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0] ?? null;
-    setFormData((prev) => ({ ...prev, file }));
-  };
-
-  const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const { name, value } = e.target;
-    setFormData((prev) => ({ ...prev, [name]: value }));
-  };
-
   return (
     <div>
-      <Form onSubmit={handleSubmit} className="mb-8">
-        <Row className="mb-3">
-          <Input
-            label="File"
-            type="file"
-            onChange={handleFileChange}
-            // error={fieldErrors.file}
-            name="file"
-            md={7}
-            required
-          />
-        </Row>
-        <Row className="mb-3">
-          <Select
-            label="Priority"
-            name="priority"
-            value={formData.priority}
-            onChange={handleSelectChange}
-            md={7}
-            // error={fieldErrors.priority}
-          >
-            <option value="low">Low</option>
-            <option value="medium">Medium</option>
-            <option value="high">High</option>
-          </Select>
-        </Row>
-
-        {/* TODO: Ability to validate job import without uploading */}
-        <Row className="mb-4 mt-2">
-          <Col md={7}>
-            <Button
-              variant="primary"
-              type="submit"
-              disabled={createJobImportMutation.isPending}
-              className="px-3"
-            >
-              {createJobImportMutation.isPending ? 'Saving...' : 'Create a New Import Job'}
-            </Button>
-          </Col>
-        </Row>
-      </Form>
+      <ImportJobForm />
     </div>
   );
 };

--- a/app/frontend/src/app/routes/import-jobs/view.tsx
+++ b/app/frontend/src/app/routes/import-jobs/view.tsx
@@ -1,0 +1,28 @@
+import { QueryClient } from '@tanstack/react-query';
+import { useParams, LoaderFunctionArgs } from 'react-router';
+import { ImportJobDetail } from '@/features/import-jobs/components/import-job-detail';
+import {
+  getImportJobQueryOptions,
+  useImportJobSuspenseQuery,
+} from '@/features/import-jobs/api/get-import-job';
+
+export const clientLoader =
+  (queryClient: QueryClient) =>
+  async ({ params }: LoaderFunctionArgs) => {
+    const importJobId = params.importJobId as string;
+    const importJobQuery = getImportJobQueryOptions(importJobId);
+    await queryClient.ensureQueryData(importJobQuery);
+  };
+
+const ImportJobsViewRoute = () => {
+  const params = useParams();
+  const importJobId = params.importJobId as string;
+
+  const importJobQuery = useImportJobSuspenseQuery({ importJobId });
+  const importJob = importJobQuery.data.importJob;
+  console.log('ImportJobsViewRoute importJob:', importJob);
+
+  return <ImportJobDetail importJob={importJob} />;
+};
+
+export default ImportJobsViewRoute;

--- a/app/frontend/src/app/routes/import-jobs/view.tsx
+++ b/app/frontend/src/app/routes/import-jobs/view.tsx
@@ -20,7 +20,6 @@ const ImportJobsViewRoute = () => {
 
   const importJobQuery = useImportJobSuspenseQuery({ importJobId });
   const importJob = importJobQuery.data.importJob;
-  console.log('ImportJobsViewRoute importJob:', importJob);
 
   return <ImportJobDetail importJob={importJob} />;
 };

--- a/app/frontend/src/components/top-navbar.tsx
+++ b/app/frontend/src/components/top-navbar.tsx
@@ -24,7 +24,12 @@ export default function TopNavbar() {
   };
 
   return (
-    <Navbar key={NAVBAR_EXPAND_SIZE} expand={NAVBAR_EXPAND_SIZE} className="bg-body-tertiary mb-3" data-bs-theme="dark">
+    <Navbar
+      key={NAVBAR_EXPAND_SIZE}
+      expand={NAVBAR_EXPAND_SIZE}
+      className="bg-body-tertiary mb-3"
+      data-bs-theme="dark"
+    >
       <Container>
         <Navbar.Brand as={NavLink} to="/">
           <img
@@ -45,9 +50,7 @@ export default function TopNavbar() {
           <Offcanvas.Body>
             <Nav>
               <Nav.Link href="/digital_objects">Digital Objects</Nav.Link>
-              {user?.adminForAtLeastOneProject && (
-                <Nav.Link href="/projects">Projects</Nav.Link>
-              )}
+              {user?.adminForAtLeastOneProject && <Nav.Link href="/projects">Projects</Nav.Link>}
               {user?.canEditAtLeastOneControlledVocabulary && (
                 <Nav.Link href="/controlled_vocabularies">Controlled Vocabularies</Nav.Link>
               )}
@@ -68,7 +71,9 @@ export default function TopNavbar() {
                     Users
                   </NavDropdown.Item>
                 </Authorization>
-                <NavDropdown.Item href="/import_jobs">Import Jobs</NavDropdown.Item>
+                <NavDropdown.Item as={NavLink} to="/import-jobs" end>
+                  Import Jobs
+                </NavDropdown.Item>
                 <NavDropdown.Item href="/csv_exports">CSV Exports</NavDropdown.Item>
               </NavDropdown>
             </Nav>
@@ -81,32 +86,24 @@ export default function TopNavbar() {
                 <NavDropdown.Item as={NavLink} to="/settings/project-permissions">
                   Project Permissions
                 </NavDropdown.Item>
-                <NavDropdown.Item href="/assignments">
-                  Assignments
-                </NavDropdown.Item>
+                <NavDropdown.Item href="/assignments">Assignments</NavDropdown.Item>
                 <Authorization allowedRoles={[ROLES.ADMIN]}>
                   <NavDropdown.Item href="/archived_assignments">
                     Historical Assignments
                   </NavDropdown.Item>
-                  <NavDropdown.Item href="/system_information">
-                    System Information
-                  </NavDropdown.Item>
+                  <NavDropdown.Item href="/system_information">System Information</NavDropdown.Item>
                   <NavDropdown.Divider />
                 </Authorization>
-                <NavDropdown.Item onClick={handleLogout}>
-                  Sign Out
-                </NavDropdown.Item>
-                <form
-                  ref={logoutFormRef}
-                  action="/users/sign_out"
-                  method="post"
-                  className="d-none"
-                >
+                <NavDropdown.Item onClick={handleLogout}>Sign Out</NavDropdown.Item>
+                <form ref={logoutFormRef} action="/users/sign_out" method="post" className="d-none">
                   <input type="hidden" name="_method" value="delete" />
                   <input
                     type="hidden"
                     name="authenticity_token"
-                    value={document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || ''}
+                    value={
+                      document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ||
+                      ''
+                    }
                   />
                 </form>
               </NavDropdown>
@@ -115,5 +112,5 @@ export default function TopNavbar() {
         </Navbar.Offcanvas>
       </Container>
     </Navbar>
-  )
+  );
 }

--- a/app/frontend/src/components/ui/json-editor/json-editor.tsx
+++ b/app/frontend/src/components/ui/json-editor/json-editor.tsx
@@ -1,28 +1,36 @@
-
 import { Editor, OnValidate } from '@monaco-editor/react';
 
 type JSONEditorProps = {
   value: string;
-  onChange: (value: string) => void;
+  onChange?: (value: string) => void;
   onValidate?: OnValidate;
   className?: string;
   ariaLabel?: string;
+  readOnly?: boolean;
 };
 
-export const JSONEditor = ({ value, onChange, onValidate, className, ariaLabel }: JSONEditorProps) => {
+export const JSONEditor = ({
+  value,
+  onChange,
+  onValidate,
+  className,
+  ariaLabel,
+  readOnly = false,
+}: JSONEditorProps) => {
   return (
     <Editor
       className={`border w-100 ${className ?? ''}`}
       height="400px"
       defaultLanguage="json"
       value={value}
-      defaultValue='{}'
-      onChange={(val) => onChange(val ?? '')}
+      defaultValue="{}"
+      onChange={(val) => onChange?.(val ?? '')}
       onValidate={onValidate}
       options={{
+        readOnly,
         minimap: { enabled: false },
         fontSize: 14,
-        ariaLabel: ariaLabel
+        ariaLabel,
       }}
     />
   );

--- a/app/frontend/src/components/ui/table-builder/table-builder.tsx
+++ b/app/frontend/src/components/ui/table-builder/table-builder.tsx
@@ -8,6 +8,7 @@ import {
   SortingState,
   PaginationState,
   OnChangeFn,
+  TableMeta,
 } from '@tanstack/react-table';
 import { Table as BTable } from 'react-bootstrap';
 
@@ -19,6 +20,7 @@ interface TableBuilderProps<T> {
   data: T[];
   columns: ColumnDef<T>[];
   pagination?: ServerPagination;
+  meta?: TableMeta<T>; // Used to pass additional data or functions
 }
 
 interface ServerPagination {
@@ -30,7 +32,7 @@ interface ServerPagination {
 // This is a generic table component that can be reused across different data types
 // When using this component, ensure you specify how to render each column in the column definitions
 // Docs: https://tanstack.com/table/latest/docs/guide/column-defs
-function TableBuilder<T extends object>({ data, columns, pagination }: TableBuilderProps<T>) {
+function TableBuilder<T extends object>({ data, columns, pagination, meta }: TableBuilderProps<T>) {
   // You can disable sorting specific columns or specify custom sorting functions in the column definitions
   // Docs: https://tanstack.com/table/latest/docs/api/features/sorting#column-def-options
   const [sorting, setSorting] = useState<SortingState>([]);
@@ -47,6 +49,7 @@ function TableBuilder<T extends object>({ data, columns, pagination }: TableBuil
     enableSorting: pagination ? false : true,
     getSortedRowModel: getSortedRowModel(),
     onSortingChange: setSorting,
+    meta,
     ...(pagination
       ? {
           manualPagination: true,

--- a/app/frontend/src/components/ui/table-builder/table-builder.tsx
+++ b/app/frontend/src/components/ui/table-builder/table-builder.tsx
@@ -1,29 +1,39 @@
-import { useState } from 'react'
+import { useState } from 'react';
 
 import {
   getCoreRowModel,
   useReactTable,
   ColumnDef,
   getSortedRowModel,
-  SortingState
-} from '@tanstack/react-table'
-import { Table as BTable } from 'react-bootstrap'
+  SortingState,
+  PaginationState,
+  OnChangeFn,
+} from '@tanstack/react-table';
+import { Table as BTable } from 'react-bootstrap';
 
-import TableHeader from './table-header'
-import TableRow from './table-row'
+import TableHeader from './table-header';
+import TableRow from './table-row';
+import TablePagination from './table-pagination';
 
 interface TableBuilderProps<T> {
-  data: T[]
-  columns: ColumnDef<T>[]
+  data: T[];
+  columns: ColumnDef<T>[];
+  pagination?: ServerPagination;
+}
+
+interface ServerPagination {
+  state: PaginationState;
+  onPaginationChange: OnChangeFn<PaginationState>;
+  rowCount: number;
 }
 
 // This is a generic table component that can be reused across different data types
 // When using this component, ensure you specify how to render each column in the column definitions
 // Docs: https://tanstack.com/table/latest/docs/guide/column-defs
-function TableBuilder<T extends object>({ data, columns }: TableBuilderProps<T>) {
+function TableBuilder<T extends object>({ data, columns, pagination }: TableBuilderProps<T>) {
   // You can disable sorting specific columns or specify custom sorting functions in the column definitions
   // Docs: https://tanstack.com/table/latest/docs/api/features/sorting#column-def-options
-  const [sorting, setSorting] = useState<SortingState>([])
+  const [sorting, setSorting] = useState<SortingState>([]);
 
   const table = useReactTable<T>({
     data,
@@ -31,32 +41,44 @@ function TableBuilder<T extends object>({ data, columns }: TableBuilderProps<T>)
     getCoreRowModel: getCoreRowModel(),
     state: {
       sorting,
+      ...(pagination ? { pagination: pagination.state } : {}),
     },
+    // Disable sorting when using server-side pagination; temporary workaround until we implement server-side sorting
+    enableSorting: pagination ? false : true,
     getSortedRowModel: getSortedRowModel(),
     onSortingChange: setSorting,
-  })
+    ...(pagination
+      ? {
+          manualPagination: true,
+          rowCount: pagination.rowCount,
+          onPaginationChange: pagination.onPaginationChange,
+        }
+      : {}),
+  });
 
   return (
-    <BTable striped bordered hover responsive size="md" className="rounded-4">
-      {table.getHeaderGroups().map((headerGroup) => (
-        <TableHeader
-          key={headerGroup.id}
-          headerGroup={headerGroup} />
-      ))}
-      <tbody>
-        {table.getRowModel().rows.length === 0 && (
-          <tr>
-            <td colSpan={columns.length} className="text-center py-3">
-              No entries found.
-            </td>
-          </tr>
-        )}
-        {table.getRowModel().rows.map((row) => (
-          <TableRow row={row} key={row.id} />
+    <>
+      {pagination && <TablePagination table={table} />}
+
+      <BTable striped bordered hover responsive size="md" className="rounded-4">
+        {table.getHeaderGroups().map((headerGroup) => (
+          <TableHeader key={headerGroup.id} headerGroup={headerGroup} />
         ))}
-      </tbody>
-    </BTable>
-  )
+        <tbody>
+          {table.getRowModel().rows.length === 0 && (
+            <tr>
+              <td colSpan={columns.length} className="text-center py-3">
+                No entries found.
+              </td>
+            </tr>
+          )}
+          {table.getRowModel().rows.map((row) => (
+            <TableRow row={row} key={row.id} />
+          ))}
+        </tbody>
+      </BTable>
+    </>
+  );
 }
 
 export default TableBuilder;

--- a/app/frontend/src/components/ui/table-builder/table-builder.tsx
+++ b/app/frontend/src/components/ui/table-builder/table-builder.tsx
@@ -21,6 +21,7 @@ interface TableBuilderProps<T> {
   columns: ColumnDef<T>[];
   pagination?: ServerPagination;
   meta?: TableMeta<T>; // Used to pass additional data or functions
+  size?: 'sm' | 'md';
 }
 
 interface ServerPagination {
@@ -32,7 +33,13 @@ interface ServerPagination {
 // This is a generic table component that can be reused across different data types
 // When using this component, ensure you specify how to render each column in the column definitions
 // Docs: https://tanstack.com/table/latest/docs/guide/column-defs
-function TableBuilder<T extends object>({ data, columns, pagination, meta }: TableBuilderProps<T>) {
+function TableBuilder<T extends object>({
+  data,
+  columns,
+  pagination,
+  meta,
+  size = 'md',
+}: TableBuilderProps<T>) {
   // You can disable sorting specific columns or specify custom sorting functions in the column definitions
   // Docs: https://tanstack.com/table/latest/docs/api/features/sorting#column-def-options
   const [sorting, setSorting] = useState<SortingState>([]);
@@ -63,7 +70,7 @@ function TableBuilder<T extends object>({ data, columns, pagination, meta }: Tab
     <>
       {pagination && <TablePagination table={table} />}
 
-      <BTable striped bordered hover responsive size="md" className="rounded-4">
+      <BTable striped bordered hover responsive size={size} className="rounded-4">
         {table.getHeaderGroups().map((headerGroup) => (
           <TableHeader key={headerGroup.id} headerGroup={headerGroup} />
         ))}

--- a/app/frontend/src/components/ui/table-builder/table-pagination.tsx
+++ b/app/frontend/src/components/ui/table-builder/table-pagination.tsx
@@ -1,0 +1,36 @@
+import { Table } from '@tanstack/react-table';
+import { Pagination } from 'react-bootstrap';
+
+interface TablePaginationProps<T> {
+  table: Table<T>;
+}
+
+function TablePagination<T>({ table }: TablePaginationProps<T>) {
+  const { pageIndex, pageSize } = table.getState().pagination;
+
+  const totalRows = table.options.rowCount ?? 0;
+
+  const pageCount = Math.max(table.getPageCount(), 1);
+  const startRow = totalRows === 0 ? 0 : pageIndex * pageSize + 1;
+  const endRow = Math.min((pageIndex + 1) * pageSize, totalRows);
+
+  return (
+    <Pagination className="mt-2 align-items-center">
+      <Pagination.First onClick={() => table.firstPage()} disabled={!table.getCanPreviousPage()} />
+      <Pagination.Prev
+        onClick={() => table.previousPage()}
+        disabled={!table.getCanPreviousPage()}
+      />
+      <Pagination.Item active>
+        {pageIndex + 1} of {pageCount}
+      </Pagination.Item>
+      <Pagination.Next onClick={() => table.nextPage()} disabled={!table.getCanNextPage()} />
+      <Pagination.Last onClick={() => table.lastPage()} disabled={!table.getCanNextPage()} />
+      <div className="d-flex align-items-center p-2">
+        Showing {startRow}-{endRow} of {totalRows}
+      </div>
+    </Pagination>
+  );
+}
+
+export default TablePagination;

--- a/app/frontend/src/features/digital-object-imports/api/get-digital-object-import.ts
+++ b/app/frontend/src/features/digital-object-imports/api/get-digital-object-import.ts
@@ -1,0 +1,50 @@
+import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api-client';
+import { QueryConfig } from '@/lib/react-query';
+import { DigitalObjectImport } from '@/types/api';
+
+export const getDigitalObjectImport = async ({
+  importJobId,
+  digitalObjectImportId,
+}: {
+  importJobId: string;
+  digitalObjectImportId: string;
+}): Promise<{ digitalObjectImport: DigitalObjectImport }> => {
+  const res = await api.get<{ digitalObjectImport: DigitalObjectImport }>(
+    `/import_jobs/${importJobId}/digital_object_imports/${digitalObjectImportId}`,
+  );
+  return res;
+};
+
+export const getDigitalObjectImportQueryOptions = ({
+  importJobId,
+  digitalObjectImportId,
+}: {
+  importJobId: string;
+  digitalObjectImportId: string;
+}) => {
+  return queryOptions({
+    queryKey: ['digital-object-imports', importJobId, digitalObjectImportId],
+    queryFn: () => getDigitalObjectImport({ importJobId, digitalObjectImportId }),
+  });
+};
+
+type UseImportJobOptions = {
+  importJobId: string;
+  digitalObjectImportId: string;
+  queryConfig?: QueryConfig<typeof getDigitalObjectImportQueryOptions>;
+};
+
+export const useDigitalObjectImportSuspenseQuery = ({
+  importJobId,
+  digitalObjectImportId,
+  queryConfig,
+}: UseImportJobOptions) => {
+  return useSuspenseQuery({
+    ...getDigitalObjectImportQueryOptions({
+      importJobId: importJobId!,
+      digitalObjectImportId: digitalObjectImportId!,
+    }),
+    ...queryConfig,
+  });
+};

--- a/app/frontend/src/features/digital-object-imports/api/get-digital-object-imports.ts
+++ b/app/frontend/src/features/digital-object-imports/api/get-digital-object-imports.ts
@@ -8,6 +8,7 @@ export interface DigitalObjectImportsResponse {
   digitalObjectImports: DigitalObjectImportSummary[];
   pagination: Pagination;
   statusFilter: string | null;
+  importJobName: string;
 }
 
 interface DigitalObjectImportsQueryParams {

--- a/app/frontend/src/features/digital-object-imports/api/get-digital-object-imports.ts
+++ b/app/frontend/src/features/digital-object-imports/api/get-digital-object-imports.ts
@@ -1,8 +1,6 @@
 import { queryOptions, useSuspenseQuery, keepPreviousData } from '@tanstack/react-query';
 import { api } from '@/lib/api-client';
-import { DigitalObjectImportSummary } from '@/types/api';
-// TODO: Move pagination into a shared type file since it's used in multiple places
-import { Pagination } from '@/features/import-jobs/api/get-import-jobs';
+import { DigitalObjectImportSummary, Pagination } from '@/types/api';
 
 export interface DigitalObjectImportsResponse {
   digitalObjectImports: DigitalObjectImportSummary[];
@@ -43,7 +41,7 @@ export const getDigitalObjectImportsQueryOptions = ({
 
 export const useDigitalObjectImportsSuspenseQuery = (params: DigitalObjectImportsQueryParams) => {
   return useSuspenseQuery({
+    placeholderData: keepPreviousData,
     ...getDigitalObjectImportsQueryOptions(params),
-    // placeholderData: keepPreviousData,
   });
 };

--- a/app/frontend/src/features/digital-object-imports/api/get-digital-object-imports.ts
+++ b/app/frontend/src/features/digital-object-imports/api/get-digital-object-imports.ts
@@ -1,0 +1,48 @@
+import { queryOptions, useSuspenseQuery, keepPreviousData } from '@tanstack/react-query';
+import { api } from '@/lib/api-client';
+import { DigitalObjectImportSummary } from '@/types/api';
+// TODO: Move pagination into a shared type file since it's used in multiple places
+import { Pagination } from '@/features/import-jobs/api/get-import-jobs';
+
+export interface DigitalObjectImportsResponse {
+  digitalObjectImports: DigitalObjectImportSummary[];
+  pagination: Pagination;
+  statusFilter: string | null;
+}
+
+interface DigitalObjectImportsQueryParams {
+  importJobId: string;
+  page?: number;
+  status?: string;
+}
+
+export const getDigitalObjectImports = ({
+  importJobId,
+  page = 1,
+  status,
+}: DigitalObjectImportsQueryParams): Promise<DigitalObjectImportsResponse> => {
+  const query = new URLSearchParams({ page: String(page) });
+  if (status) query.set('status', status);
+
+  return api.get<DigitalObjectImportsResponse>(
+    `/import_jobs/${importJobId}/digital_object_imports?${query.toString()}`,
+  );
+};
+
+export const getDigitalObjectImportsQueryOptions = ({
+  importJobId,
+  page = 1,
+  status,
+}: DigitalObjectImportsQueryParams) => {
+  return queryOptions({
+    queryKey: ['digital-object-imports', importJobId, { page, status: status ?? null }],
+    queryFn: () => getDigitalObjectImports({ importJobId, page, status }),
+  });
+};
+
+export const useDigitalObjectImportsSuspenseQuery = (params: DigitalObjectImportsQueryParams) => {
+  return useSuspenseQuery({
+    ...getDigitalObjectImportsQueryOptions(params),
+    // placeholderData: keepPreviousData,
+  });
+};

--- a/app/frontend/src/features/digital-object-imports/components/digital-object-detail.tsx
+++ b/app/frontend/src/features/digital-object-imports/components/digital-object-detail.tsx
@@ -1,7 +1,8 @@
-import { Link } from 'react-router';
-import { Badge, Card, Col, Row } from 'react-bootstrap';
+import { Link, useNavigate } from 'react-router';
+import { Badge, Button, Card, Col, Row } from 'react-bootstrap';
 import { JSONEditor } from '@/components/ui/json-editor/json-editor';
 import { DigitalObjectImport } from '@/types/api';
+import { ArrowLeft } from 'react-bootstrap-icons';
 
 const STATUS_VARIANT: Record<string, string> = {
   pending: 'secondary',
@@ -38,9 +39,21 @@ export const DigitalObjectDetail = ({ digitalObjectImport }: DigitalObjectDetail
   const hasErrors = digitalObjectErrors && digitalObjectErrors.length > 0;
   const formatted = formatDigitalObjectData(digitalObjectData);
 
+  const navigate = useNavigate();
+
   return (
     <div>
-      <div className="d-flex align-items-center gap-2 mb-4">
+      <Button
+        variant="outline-secondary"
+        size="sm"
+        className="d-flex align-items-center gap-1"
+        onClick={() => navigate('..', { relative: 'path' })}
+      >
+        <ArrowLeft size={18} />
+        Back to the list of digital object imports
+      </Button>
+
+      <div className="d-flex align-items-center gap-2 my-4">
         <h2 className="mb-0">Digital Object Import</h2>
         <span className="text-muted">#{id}</span>
         <Badge bg={STATUS_VARIANT[status]} className="ms-1 text-capitalize">

--- a/app/frontend/src/features/digital-object-imports/components/digital-object-detail.tsx
+++ b/app/frontend/src/features/digital-object-imports/components/digital-object-detail.tsx
@@ -1,8 +1,9 @@
 import { Link, useNavigate } from 'react-router';
 import { Badge, Button, Card, Col, Row } from 'react-bootstrap';
+import { ArrowLeft } from 'react-bootstrap-icons';
 import { JSONEditor } from '@/components/ui/json-editor/json-editor';
 import { DigitalObjectImport } from '@/types/api';
-import { ArrowLeft } from 'react-bootstrap-icons';
+import { formatLocalDateTime } from '@/utils/format';
 
 const STATUS_VARIANT: Record<string, string> = {
   pending: 'secondary',
@@ -88,11 +89,11 @@ export const DigitalObjectDetail = ({ digitalObjectImport }: DigitalObjectDetail
             </Col>
             <Col md={4}>
               <dt className="fw-semibold text-secondary small text-uppercase mb-1">Created</dt>
-              <dd className="mb-0">{createdAt}</dd>
+              <dd className="mb-0">{formatLocalDateTime(createdAt)}</dd>
             </Col>
             <Col md={4}>
               <dt className="fw-semibold text-secondary small text-uppercase mb-1">Updated</dt>
-              <dd className="mb-0">{updatedAt}</dd>
+              <dd className="mb-0">{formatLocalDateTime(updatedAt)}</dd>
             </Col>
           </Row>
         </Card.Body>

--- a/app/frontend/src/features/digital-object-imports/components/digital-object-detail.tsx
+++ b/app/frontend/src/features/digital-object-imports/components/digital-object-detail.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Link, useNavigate } from 'react-router';
 import { Badge, Button, Card, Col, Row } from 'react-bootstrap';
 import { ArrowLeft } from 'react-bootstrap-icons';
@@ -41,6 +42,14 @@ export const DigitalObjectDetail = ({ digitalObjectImport }: DigitalObjectDetail
   const formatted = formatDigitalObjectData(digitalObjectData);
 
   const navigate = useNavigate();
+
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(formatted);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
 
   return (
     <div>
@@ -114,13 +123,21 @@ export const DigitalObjectDetail = ({ digitalObjectImport }: DigitalObjectDetail
         </Card>
       )}
 
-      {/* TODO: Add copy to clipboard */}
       <Card>
         <Card.Header className="d-flex align-items-center justify-content-between">
           <span className="fw-semibold">Digital Object Data (read only)</span>
-          <Badge bg="light" text="dark">
-            JSON
-          </Badge>
+          <div className="d-flex align-items-center gap-2">
+            <Button
+              variant={copied ? 'success' : 'outline-secondary'}
+              size="sm"
+              onClick={handleCopy}
+            >
+              {copied ? 'Copied!' : 'Copy JSON to Clipboard'}
+            </Button>
+            <Badge bg="light" text="dark">
+              JSON
+            </Badge>
+          </div>
         </Card.Header>
         <Card.Body className="p-0">
           <JSONEditor

--- a/app/frontend/src/features/digital-object-imports/components/digital-object-detail.tsx
+++ b/app/frontend/src/features/digital-object-imports/components/digital-object-detail.tsx
@@ -17,6 +17,7 @@ export const DigitalObjectDetail = ({ digitalObjectImport }: DigitalObjectDetail
   const {
     id,
     importJobId,
+    importJobName,
     csvRowNumber,
     status,
     digitalObjectData,
@@ -57,10 +58,10 @@ export const DigitalObjectDetail = ({ digitalObjectImport }: DigitalObjectDetail
               <dd className="mb-0">{csvRowNumber}</dd>
             </Col>
             <Col md={4}>
-              <dt className="fw-semibold text-secondary small text-uppercase mb-1">
-                View import job
-              </dt>
-              <Link to={`/import-jobs/${importJobId}`}>View import job</Link>
+              <dt className="fw-semibold text-secondary small text-uppercase mb-1">Import Job</dt>
+              <dd className="mb-0">
+                <Link to={`/import-jobs/${importJobId}`}>{importJobName}</Link>
+              </dd>
             </Col>
             <Col md={4}>
               <dt className="fw-semibold text-secondary small text-uppercase mb-1">

--- a/app/frontend/src/features/digital-object-imports/components/digital-object-detail.tsx
+++ b/app/frontend/src/features/digital-object-imports/components/digital-object-detail.tsx
@@ -1,0 +1,120 @@
+import { Link } from 'react-router';
+import { Badge, Card, Col, Row } from 'react-bootstrap';
+import { JSONEditor } from '@/components/ui/json-editor/json-editor';
+import { DigitalObjectImport } from '@/types/api';
+
+const STATUS_VARIANT: Record<string, string> = {
+  pending: 'secondary',
+  success: 'success',
+  failure: 'danger',
+};
+
+interface DigitalObjectDetailProps {
+  digitalObjectImport: DigitalObjectImport;
+}
+
+export const DigitalObjectDetail = ({ digitalObjectImport }: DigitalObjectDetailProps) => {
+  const {
+    id,
+    importJobId,
+    csvRowNumber,
+    status,
+    digitalObjectData,
+    digitalObjectErrors,
+    prerequisiteCsvRowNumbers,
+    createdAt,
+    updatedAt,
+  } = digitalObjectImport;
+
+  const formatDigitalObjectData = (raw: string) => {
+    try {
+      return JSON.stringify(JSON.parse(raw), null, 2);
+    } catch {
+      return raw;
+    }
+  };
+
+  const hasErrors = digitalObjectErrors && digitalObjectErrors.length > 0;
+  const formatted = formatDigitalObjectData(digitalObjectData);
+
+  return (
+    <div>
+      <div className="d-flex align-items-center gap-2 mb-4">
+        <h2 className="mb-0">Digital Object Import</h2>
+        <span className="text-muted">#{id}</span>
+        <Badge bg={STATUS_VARIANT[status]} className="ms-1 text-capitalize">
+          {status}
+        </Badge>
+      </div>
+
+      <Card className="mb-4">
+        <Card.Body>
+          <Row className="g-3">
+            <Col md={4}>
+              <dt className="fw-semibold text-secondary small text-uppercase mb-1">
+                CSV Row Number
+              </dt>
+              <dd className="mb-0">{csvRowNumber}</dd>
+            </Col>
+            <Col md={4}>
+              <dt className="fw-semibold text-secondary small text-uppercase mb-1">
+                View import job
+              </dt>
+              <Link to={`/import-jobs/${importJobId}`}>View import job</Link>
+            </Col>
+            <Col md={4}>
+              <dt className="fw-semibold text-secondary small text-uppercase mb-1">
+                Prerequisite CSV Row Numbers
+              </dt>
+              <dd className="mb-0">
+                {prerequisiteCsvRowNumbers && prerequisiteCsvRowNumbers.length > 0
+                  ? prerequisiteCsvRowNumbers.join(', ')
+                  : 'None'}
+              </dd>
+            </Col>
+            <Col md={4}>
+              <dt className="fw-semibold text-secondary small text-uppercase mb-1">Created</dt>
+              <dd className="mb-0">{createdAt}</dd>
+            </Col>
+            <Col md={4}>
+              <dt className="fw-semibold text-secondary small text-uppercase mb-1">Updated</dt>
+              <dd className="mb-0">{updatedAt}</dd>
+            </Col>
+          </Row>
+        </Card.Body>
+      </Card>
+
+      {hasErrors && (
+        <Card className="mb-4 border-danger border-opacity-25">
+          <Card.Header className="bg-danger-subtle text-danger-emphasis fw-semibold">
+            Errors
+          </Card.Header>
+          <Card.Body>
+            <ul className="mb-0">
+              {digitalObjectErrors.map((error, i) => (
+                <li key={i}>{error}</li>
+              ))}
+            </ul>
+          </Card.Body>
+        </Card>
+      )}
+
+      {/* TODO: Add copy to clipboard */}
+      <Card>
+        <Card.Header className="d-flex align-items-center justify-content-between">
+          <span className="fw-semibold">Digital Object Data (read only)</span>
+          <Badge bg="light" text="dark">
+            JSON
+          </Badge>
+        </Card.Header>
+        <Card.Body className="p-0">
+          <JSONEditor
+            value={formatted}
+            ariaLabel={`Digital object data for import ${id}`}
+            readOnly
+          />
+        </Card.Body>
+      </Card>
+    </div>
+  );
+};

--- a/app/frontend/src/features/digital-object-imports/components/digital-object-imports-list.tsx
+++ b/app/frontend/src/features/digital-object-imports/components/digital-object-imports-list.tsx
@@ -1,4 +1,4 @@
-import { useSearchParams } from 'react-router';
+import { Link, useSearchParams } from 'react-router';
 import type { ColumnDef, PaginationState, Updater } from '@tanstack/react-table';
 import TableBuilder from '@/components/ui/table-builder/table-builder';
 import { columnDefs } from '../utils/digital-object-imports-column-defs';
@@ -49,7 +49,9 @@ export const DigitalObjectImportsList = ({ importJobId }: DigitalObjectImportsLi
 
   return (
     <>
-      <h2 className="mb-4">Digital Object Imports for {importJobName}</h2>
+      <h2 className="mb-4">
+        Digital Object Imports for <Link to={`/import-jobs/${importJobId}`}>{importJobName}</Link>
+      </h2>
 
       {/* TODO: This component shares the navigation that import-jobs-list.tsx uses, change it so the back button leads to the import job details */}
       <StatusFilter active={status ?? null} options={options} onChange={handleStatusChange} />

--- a/app/frontend/src/features/digital-object-imports/components/digital-object-imports-list.tsx
+++ b/app/frontend/src/features/digital-object-imports/components/digital-object-imports-list.tsx
@@ -1,0 +1,4 @@
+export const DigitalObjectImportsList = ({ importJobId }: { importJobId: string }) => {
+  console.log('DigitalObjectImportsList importJobId:', importJobId);
+  return <div>hi</div>;
+};

--- a/app/frontend/src/features/digital-object-imports/components/digital-object-imports-list.tsx
+++ b/app/frontend/src/features/digital-object-imports/components/digital-object-imports-list.tsx
@@ -1,10 +1,10 @@
 import { useSearchParams } from 'react-router';
-import { Button, ButtonGroup } from 'react-bootstrap';
 import type { ColumnDef, PaginationState, Updater } from '@tanstack/react-table';
 import TableBuilder from '@/components/ui/table-builder/table-builder';
 import { columnDefs } from '../utils/digital-object-imports-column-defs';
 import { useDigitalObjectImportsSuspenseQuery } from '../api/get-digital-object-imports';
 import { DigitalObjectImportSummary } from '@/types/api';
+import { StatusFilter } from './status-filter';
 
 interface DigitalObjectImportsListProps {
   importJobId: string;
@@ -50,25 +50,7 @@ export const DigitalObjectImportsList = ({ importJobId }: DigitalObjectImportsLi
   return (
     <>
       {/* TODO: This component shares the navigation that import-jobs-list.tsx uses, change it so the back button leads to the import job details */}
-      {/* TODO: Make it a separate component */}
-      <ButtonGroup className="mb-3" size="sm">
-        <Button
-          variant={status === null ? 'secondary' : 'outline-secondary'}
-          onClick={() => handleStatusChange(null)}
-        >
-          All
-        </Button>
-        {options.map((statusOption) => (
-          <Button
-            key={statusOption}
-            variant={status === statusOption ? 'secondary' : 'outline-secondary'}
-            onClick={() => handleStatusChange(statusOption)}
-            className="text-capitalize"
-          >
-            {statusOption}
-          </Button>
-        ))}
-      </ButtonGroup>
+      <StatusFilter active={status ?? null} options={options} onChange={handleStatusChange} />
 
       <TableBuilder
         data={digitalObjectImports}

--- a/app/frontend/src/features/digital-object-imports/components/digital-object-imports-list.tsx
+++ b/app/frontend/src/features/digital-object-imports/components/digital-object-imports-list.tsx
@@ -1,4 +1,84 @@
-export const DigitalObjectImportsList = ({ importJobId }: { importJobId: string }) => {
-  console.log('DigitalObjectImportsList importJobId:', importJobId);
-  return <div>hi</div>;
+import { useSearchParams } from 'react-router';
+import { Button, ButtonGroup } from 'react-bootstrap';
+import type { ColumnDef, PaginationState, Updater } from '@tanstack/react-table';
+import TableBuilder from '@/components/ui/table-builder/table-builder';
+import { columnDefs } from '../utils/digital-object-imports-column-defs';
+import { useDigitalObjectImportsSuspenseQuery } from '../api/get-digital-object-imports';
+import { DigitalObjectImportSummary } from '@/types/api';
+
+interface DigitalObjectImportsListProps {
+  importJobId: string;
+}
+
+const options = ['pending', 'success', 'failure'];
+
+export const DigitalObjectImportsList = ({ importJobId }: DigitalObjectImportsListProps) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const page = Number(searchParams.get('page')) || 1;
+  const status = searchParams.get('status') ?? undefined;
+
+  const query = useDigitalObjectImportsSuspenseQuery({ importJobId, page, status });
+  const { digitalObjectImports, pagination } = query.data;
+
+  // same logic as in import-jobs-list.tsx, could this be refactored/extracted?
+  const paginationState: PaginationState = {
+    pageIndex: page - 1,
+    pageSize: pagination.perPage,
+  };
+
+  // same logic as in import-jobs-list.tsx, could this be refactored/extracted?
+  const handlePaginationChange = (updater: Updater<PaginationState>) => {
+    const next = typeof updater === 'function' ? updater(paginationState) : updater;
+    setSearchParams((prev) => {
+      prev.set('page', String(next.pageIndex + 1));
+      return prev;
+    });
+  };
+
+  const handleStatusChange = (newStatus: string | null) => {
+    setSearchParams((prev) => {
+      if (newStatus) {
+        prev.set('status', newStatus);
+      } else {
+        prev.delete('status');
+      }
+      prev.delete('page'); // Resets to page 1 whenever the filter changes
+      return prev;
+    });
+  };
+
+  return (
+    <>
+      {/* TODO: This component shares the navigation that import-jobs-list.tsx uses, change it so the back button leads to the import job details */}
+      {/* TODO: Make it a separate component */}
+      <ButtonGroup className="mb-3" size="sm">
+        <Button
+          variant={status === null ? 'secondary' : 'outline-secondary'}
+          onClick={() => handleStatusChange(null)}
+        >
+          All
+        </Button>
+        {options.map((statusOption) => (
+          <Button
+            key={statusOption}
+            variant={status === statusOption ? 'secondary' : 'outline-secondary'}
+            onClick={() => handleStatusChange(statusOption)}
+            className="text-capitalize"
+          >
+            {statusOption}
+          </Button>
+        ))}
+      </ButtonGroup>
+
+      <TableBuilder
+        data={digitalObjectImports}
+        columns={columnDefs as ColumnDef<DigitalObjectImportSummary>[]}
+        pagination={{
+          state: paginationState,
+          onPaginationChange: handlePaginationChange,
+          rowCount: pagination.totalCount,
+        }}
+      />
+    </>
+  );
 };

--- a/app/frontend/src/features/digital-object-imports/components/digital-object-imports-list.tsx
+++ b/app/frontend/src/features/digital-object-imports/components/digital-object-imports-list.tsx
@@ -48,22 +48,33 @@ export const DigitalObjectImportsList = ({ importJobId }: DigitalObjectImportsLi
   };
 
   return (
-    <>
-      <h2 className="mb-4">
-        Digital Object Imports for <Link to={`/import-jobs/${importJobId}`}>{importJobName}</Link>
-      </h2>
+    <div>
+      <div className="mb-4">
+        <div className="text-secondary small text-uppercase fw-semibold mb-1">
+          Digital object imports
+        </div>
+        <h2 className="mb-0">
+          <Link
+            to={`/import-jobs/${importJobId}`}
+            className="link-underline link-underline-opacity-0 link-underline-opacity-75-hover"
+          >
+            {importJobName}
+          </Link>
+        </h2>
+      </div>
 
       <StatusFilter active={status ?? null} options={options} onChange={handleStatusChange} />
 
       <TableBuilder
         data={digitalObjectImports}
         columns={columnDefs as ColumnDef<DigitalObjectImportSummary>[]}
+        size="sm"
         pagination={{
           state: paginationState,
           onPaginationChange: handlePaginationChange,
           rowCount: pagination.totalCount,
         }}
       />
-    </>
+    </div>
   );
 };

--- a/app/frontend/src/features/digital-object-imports/components/digital-object-imports-list.tsx
+++ b/app/frontend/src/features/digital-object-imports/components/digital-object-imports-list.tsx
@@ -20,13 +20,13 @@ export const DigitalObjectImportsList = ({ importJobId }: DigitalObjectImportsLi
   const query = useDigitalObjectImportsSuspenseQuery({ importJobId, page, status });
   const { digitalObjectImports, pagination, importJobName } = query.data;
 
-  // same logic as in import-jobs-list.tsx, could this be refactored/extracted?
+  // TODO: This is the same logic as in import-jobs-list.tsx; might work well as a custom hook
   const paginationState: PaginationState = {
     pageIndex: page - 1,
     pageSize: pagination.perPage,
   };
 
-  // same logic as in import-jobs-list.tsx, could this be refactored/extracted?
+  // TODO: This is the same logic as in import-jobs-list.tsx; might work well as a custom hook
   const handlePaginationChange = (updater: Updater<PaginationState>) => {
     const next = typeof updater === 'function' ? updater(paginationState) : updater;
     setSearchParams((prev) => {
@@ -53,7 +53,6 @@ export const DigitalObjectImportsList = ({ importJobId }: DigitalObjectImportsLi
         Digital Object Imports for <Link to={`/import-jobs/${importJobId}`}>{importJobName}</Link>
       </h2>
 
-      {/* TODO: This component shares the navigation that import-jobs-list.tsx uses, change it so the back button leads to the import job details */}
       <StatusFilter active={status ?? null} options={options} onChange={handleStatusChange} />
 
       <TableBuilder

--- a/app/frontend/src/features/digital-object-imports/components/digital-object-imports-list.tsx
+++ b/app/frontend/src/features/digital-object-imports/components/digital-object-imports-list.tsx
@@ -18,7 +18,7 @@ export const DigitalObjectImportsList = ({ importJobId }: DigitalObjectImportsLi
   const status = searchParams.get('status') ?? undefined;
 
   const query = useDigitalObjectImportsSuspenseQuery({ importJobId, page, status });
-  const { digitalObjectImports, pagination } = query.data;
+  const { digitalObjectImports, pagination, importJobName } = query.data;
 
   // same logic as in import-jobs-list.tsx, could this be refactored/extracted?
   const paginationState: PaginationState = {
@@ -49,6 +49,8 @@ export const DigitalObjectImportsList = ({ importJobId }: DigitalObjectImportsLi
 
   return (
     <>
+      <h2 className="mb-4">Digital Object Imports for {importJobName}</h2>
+
       {/* TODO: This component shares the navigation that import-jobs-list.tsx uses, change it so the back button leads to the import job details */}
       <StatusFilter active={status ?? null} options={options} onChange={handleStatusChange} />
 

--- a/app/frontend/src/features/digital-object-imports/components/status-filter.tsx
+++ b/app/frontend/src/features/digital-object-imports/components/status-filter.tsx
@@ -1,0 +1,30 @@
+import { Button, ButtonGroup } from 'react-bootstrap';
+
+interface StatusFilterProps {
+  active: string | null;
+  options: string[];
+  onChange: (status: string | null) => void;
+}
+
+export const StatusFilter = ({ active, options, onChange }: StatusFilterProps) => {
+  return (
+    <ButtonGroup className="mb-3" size="sm">
+      <Button
+        variant={active === null ? 'secondary' : 'outline-secondary'}
+        onClick={() => onChange(null)}
+      >
+        All
+      </Button>
+      {options.map((status) => (
+        <Button
+          key={status}
+          variant={active === status ? 'secondary' : 'outline-secondary'}
+          onClick={() => onChange(status)}
+          className="text-capitalize"
+        >
+          {status}
+        </Button>
+      ))}
+    </ButtonGroup>
+  );
+};

--- a/app/frontend/src/features/digital-object-imports/utils/digital-object-imports-column-defs.tsx
+++ b/app/frontend/src/features/digital-object-imports/utils/digital-object-imports-column-defs.tsx
@@ -1,0 +1,27 @@
+import { createColumnHelper } from '@tanstack/react-table';
+import { DigitalObjectImportSummary } from '@/types/api';
+
+const columnHelper = createColumnHelper<DigitalObjectImportSummary>();
+
+export const columnDefs = [
+  columnHelper.accessor('id', {
+    header: 'Id',
+    cell: (info) => info.getValue(), // TODO: add link to digital object import details page
+  }),
+  columnHelper.accessor('csvRowNumber', {
+    header: 'CSV Row Number',
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor('status', {
+    header: 'Status',
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor('createdAt', {
+    header: 'Created At',
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor('updatedAt', {
+    header: 'Updated At',
+    cell: (info) => info.getValue(),
+  }),
+];

--- a/app/frontend/src/features/digital-object-imports/utils/digital-object-imports-column-defs.tsx
+++ b/app/frontend/src/features/digital-object-imports/utils/digital-object-imports-column-defs.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router';
 import { createColumnHelper } from '@tanstack/react-table';
 import { DigitalObjectImportSummary } from '@/types/api';
 
@@ -6,7 +7,14 @@ const columnHelper = createColumnHelper<DigitalObjectImportSummary>();
 export const columnDefs = [
   columnHelper.accessor('id', {
     header: 'Id',
-    cell: (info) => info.getValue(), // TODO: add link to digital object import details page
+    cell: ({ row }) => (
+      <Link
+        to={{ pathname: `${row.original.id}` }}
+        className="link-underline link-underline-opacity-0 link-underline-opacity-75-hover"
+      >
+        <span>{row.original.id}</span>
+      </Link>
+    ),
   }),
   columnHelper.accessor('csvRowNumber', {
     header: 'CSV Row Number',

--- a/app/frontend/src/features/digital-object-imports/utils/digital-object-imports-column-defs.tsx
+++ b/app/frontend/src/features/digital-object-imports/utils/digital-object-imports-column-defs.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router';
 import { createColumnHelper } from '@tanstack/react-table';
 import { DigitalObjectImportSummary } from '@/types/api';
+import { formatLocalDateTime } from '@/utils/format';
 
 const columnHelper = createColumnHelper<DigitalObjectImportSummary>();
 
@@ -26,10 +27,10 @@ export const columnDefs = [
   }),
   columnHelper.accessor('createdAt', {
     header: 'Created At',
-    cell: (info) => info.getValue(),
+    cell: (info) => formatLocalDateTime(info.getValue() || '') || 'Unknown',
   }),
   columnHelper.accessor('updatedAt', {
     header: 'Updated At',
-    cell: (info) => info.getValue(),
+    cell: (info) => formatLocalDateTime(info.getValue() || '') || 'Unknown',
   }),
 ];

--- a/app/frontend/src/features/import-jobs/api/create-import-job.ts
+++ b/app/frontend/src/features/import-jobs/api/create-import-job.ts
@@ -38,7 +38,7 @@ export const useCreateImportJob = ({ mutationConfig }: UseCreateImportJobOptions
   return useMutation({
     onSuccess: (...args) => {
       queryClient.invalidateQueries({
-        queryKey: ['import-jobs'], // TODO: replace with const
+        queryKey: ['import-jobs'],
       });
       onSuccess?.(...args);
     },

--- a/app/frontend/src/features/import-jobs/api/create-import-job.ts
+++ b/app/frontend/src/features/import-jobs/api/create-import-job.ts
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '@/lib/api-client';
 import { MutationConfig } from '@/lib/react-query';
 
-export const createimportJob = ({
+export const createImportJob = ({
   data,
 }: {
   data: { file: File; priority: string };
@@ -15,11 +15,11 @@ export const createimportJob = ({
   return api.post(`/import_jobs`, formData);
 };
 
-type UseCreateimportJobOptions = {
-  mutationConfig?: MutationConfig<typeof createimportJob>;
+type UseCreateImportJobOptions = {
+  mutationConfig?: MutationConfig<typeof createImportJob>;
 };
 
-export const useCreateImportJob = ({ mutationConfig }: UseCreateimportJobOptions = {}) => {
+export const useCreateImportJob = ({ mutationConfig }: UseCreateImportJobOptions = {}) => {
   const queryClient = useQueryClient();
 
   const { onSuccess, ...restConfig } = mutationConfig || {};
@@ -32,6 +32,6 @@ export const useCreateImportJob = ({ mutationConfig }: UseCreateimportJobOptions
       onSuccess?.(...args);
     },
     ...restConfig,
-    mutationFn: createimportJob,
+    mutationFn: createImportJob,
   });
 };

--- a/app/frontend/src/features/import-jobs/api/create-import-job.ts
+++ b/app/frontend/src/features/import-jobs/api/create-import-job.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/lib/api-client';
+import { MutationConfig } from '@/lib/react-query';
+
+export const createimportJob = ({
+  data,
+}: {
+  data: { file: File; priority: string };
+}): Promise<{ importJob: any }> => {
+  const formData = new FormData();
+  formData.append('import_file', data.file);
+  formData.append('import_job[priority]', data.priority);
+
+  return api.post(`/import_jobs`, formData);
+};
+
+type UseCreateimportJobOptions = {
+  mutationConfig?: MutationConfig<typeof createimportJob>;
+};
+
+export const useCreateImportJob = ({ mutationConfig }: UseCreateimportJobOptions = {}) => {
+  const queryClient = useQueryClient();
+
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+
+  return useMutation({
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: ['import-jobs'], // TODO: replace with const
+      });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: createimportJob,
+  });
+};

--- a/app/frontend/src/features/import-jobs/api/create-import-job.ts
+++ b/app/frontend/src/features/import-jobs/api/create-import-job.ts
@@ -2,17 +2,28 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { api } from '@/lib/api-client';
 import { MutationConfig } from '@/lib/react-query';
+import { ImportJobSummary } from '@/types/api';
+
+export type CreateImportJobInput = {
+  data: {
+    file: File;
+    priority: string;
+    restoreArchivedS3ObjectsForNewAssets: boolean;
+  };
+};
 
 export const createImportJob = ({
   data,
-}: {
-  data: { file: File; priority: string };
-}): Promise<{ importJob: any }> => {
+}: CreateImportJobInput): Promise<{ importJob: ImportJobSummary }> => {
   const formData = new FormData();
   formData.append('import_file', data.file);
-  formData.append('import_job[priority]', data.priority);
+  formData.append('priority', data.priority);
+  formData.append(
+    'restore_archived_s3_objects_for_new_assets',
+    String(data.restoreArchivedS3ObjectsForNewAssets),
+  );
 
-  return api.post(`/import_jobs`, formData);
+  return api.post('/import_jobs', formData);
 };
 
 type UseCreateImportJobOptions = {

--- a/app/frontend/src/features/import-jobs/api/delete-import-job.ts
+++ b/app/frontend/src/features/import-jobs/api/delete-import-job.ts
@@ -1,0 +1,36 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/lib/api-client';
+import { MutationConfig } from '@/lib/react-query';
+import { getImportJobQueryOptions } from './get-import-job';
+
+export const deleteImportJob = ({
+  importJobId,
+}: {
+  importJobId: string;
+}): Promise<Record<string, never>> => {
+  return api.delete(`/import_jobs/${importJobId}`);
+};
+
+type UseDeleteImportJobOptions = {
+  mutationConfig?: MutationConfig<typeof deleteImportJob>;
+};
+
+export const useDeleteImportJob = ({ mutationConfig }: UseDeleteImportJobOptions = {}) => {
+  const queryClient = useQueryClient();
+
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+
+  return useMutation({
+    onSuccess: (data, variables, ...args) => {
+      queryClient.removeQueries({
+        queryKey: getImportJobQueryOptions(variables.importJobId).queryKey,
+      });
+      // Refetch the list so the deleted row disappears and counts/pagination is updated
+      queryClient.invalidateQueries({ queryKey: ['import-jobs'] });
+      onSuccess?.(data, variables, ...args);
+    },
+    ...restConfig,
+    mutationFn: deleteImportJob,
+  });
+};

--- a/app/frontend/src/features/import-jobs/api/download-csv.ts
+++ b/app/frontend/src/features/import-jobs/api/download-csv.ts
@@ -1,0 +1,10 @@
+// These methods don't use the shared API client because they are used to download files which doesn't work with JSON responses.
+// Instead, these methods return the download URLs for the CSV files, which can be used in an anchor tag or a fetch request to download the files directly.
+
+import { BASE_URL } from '@/lib/api-client';
+
+export const getOriginalCsvDownloadUrl = (importJobId: number) =>
+  `${BASE_URL}/import_jobs/${importJobId}/download_original_csv`;
+
+export const getCsvWithoutSuccessfulRowsDownloadUrl = (importJobId: number) =>
+  `${BASE_URL}/import_jobs/${importJobId}/download_csv_without_successful_rows`;

--- a/app/frontend/src/features/import-jobs/api/get-import-job.ts
+++ b/app/frontend/src/features/import-jobs/api/get-import-job.ts
@@ -1,0 +1,28 @@
+import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api-client';
+import { QueryConfig } from '@/lib/react-query';
+import { ImportJob } from '@/types/api';
+
+export const getImportJob = async (importJobId: string): Promise<{ importJob: ImportJob }> => {
+  const res = await api.get<{ importJob: ImportJob }>(`/import_jobs/${importJobId}`);
+  return res;
+};
+
+export const getImportJobQueryOptions = (importJobId: string) => {
+  return queryOptions({
+    queryKey: ['import-jobs', importJobId],
+    queryFn: () => getImportJob(importJobId),
+  });
+};
+
+type UseImportJobOptions = {
+  importJobId: string;
+  queryConfig?: QueryConfig<typeof getImportJobQueryOptions>;
+};
+
+export const useImportJobSuspenseQuery = ({ importJobId, queryConfig }: UseImportJobOptions) => {
+  return useSuspenseQuery({
+    ...getImportJobQueryOptions(importJobId!),
+    ...queryConfig,
+  });
+};

--- a/app/frontend/src/features/import-jobs/api/get-import-jobs.ts
+++ b/app/frontend/src/features/import-jobs/api/get-import-jobs.ts
@@ -1,28 +1,42 @@
-import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
+import { queryOptions, useSuspenseQuery, keepPreviousData } from '@tanstack/react-query';
 import { api } from '@/lib/api-client';
 import { QueryConfig } from '@/lib/react-query';
 import { ImportJob } from '@/types/api';
 
-export const getImportJobs = async (): Promise<{ importJobs: ImportJob[] }> => {
-  const res = await api.get<{ importJobs: ImportJob[] }>('/import_jobs');
+export interface Pagination {
+  currentPage: number;
+  perPage: number;
+  totalPages: number;
+  totalCount: number;
+}
+
+export interface ImportJobsResponse {
+  importJobs: ImportJob[];
+  pagination: Pagination;
+}
+
+export const getImportJobs = async (page: number): Promise<ImportJobsResponse> => {
+  const res = await api.get<ImportJobsResponse>(`/import_jobs?page=${page}`);
   console.log('getImportJobs response:', res);
   return res;
 };
 
-export const getImportJobsQueryOptions = () => {
+export const getImportJobsQueryOptions = (page: number) => {
   return queryOptions({
-    queryKey: ['import-jobs'],
-    queryFn: getImportJobs,
+    queryKey: ['import-jobs', { page }],
+    queryFn: () => getImportJobs(page),
   });
 };
 
 type UseImportJobsOptions = {
+  page: number;
   queryConfig?: QueryConfig<typeof getImportJobsQueryOptions>;
 };
 
-export const useImportJobsSuspenseQuery = ({ queryConfig }: UseImportJobsOptions = {}) => {
+export const useImportJobsSuspenseQuery = ({ page, queryConfig }: UseImportJobsOptions) => {
   return useSuspenseQuery({
-    ...getImportJobsQueryOptions(),
+    ...getImportJobsQueryOptions(page),
+    placeholderData: keepPreviousData, // Eliminates the flash of the table when changing pages
     ...queryConfig,
   });
 };

--- a/app/frontend/src/features/import-jobs/api/get-import-jobs.ts
+++ b/app/frontend/src/features/import-jobs/api/get-import-jobs.ts
@@ -1,14 +1,7 @@
 import { queryOptions, useSuspenseQuery, keepPreviousData } from '@tanstack/react-query';
 import { api } from '@/lib/api-client';
 import { QueryConfig } from '@/lib/react-query';
-import { ImportJobSummary } from '@/types/api';
-
-export interface Pagination {
-  currentPage: number;
-  perPage: number;
-  totalPages: number;
-  totalCount: number;
-}
+import { ImportJobSummary, Pagination } from '@/types/api';
 
 export interface ImportJobsResponse {
   importJobs: ImportJobSummary[];

--- a/app/frontend/src/features/import-jobs/api/get-import-jobs.ts
+++ b/app/frontend/src/features/import-jobs/api/get-import-jobs.ts
@@ -1,0 +1,28 @@
+import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api-client';
+import { QueryConfig } from '@/lib/react-query';
+import { ImportJob } from '@/types/api';
+
+export const getImportJobs = async (): Promise<{ importJobs: ImportJob[] }> => {
+  const res = await api.get<{ importJobs: ImportJob[] }>('/import_jobs');
+  console.log('getImportJobs response:', res);
+  return res;
+};
+
+export const getImportJobsQueryOptions = () => {
+  return queryOptions({
+    queryKey: ['import-jobs'],
+    queryFn: getImportJobs,
+  });
+};
+
+type UseImportJobsOptions = {
+  queryConfig?: QueryConfig<typeof getImportJobsQueryOptions>;
+};
+
+export const useImportJobsSuspenseQuery = ({ queryConfig }: UseImportJobsOptions = {}) => {
+  return useSuspenseQuery({
+    ...getImportJobsQueryOptions(),
+    ...queryConfig,
+  });
+};

--- a/app/frontend/src/features/import-jobs/api/get-import-jobs.ts
+++ b/app/frontend/src/features/import-jobs/api/get-import-jobs.ts
@@ -17,7 +17,6 @@ export interface ImportJobsResponse {
 
 export const getImportJobs = async (page: number): Promise<ImportJobsResponse> => {
   const res = await api.get<ImportJobsResponse>(`/import_jobs?page=${page}`);
-  console.log('getImportJobs response:', res);
   return res;
 };
 

--- a/app/frontend/src/features/import-jobs/api/get-import-jobs.ts
+++ b/app/frontend/src/features/import-jobs/api/get-import-jobs.ts
@@ -1,7 +1,7 @@
 import { queryOptions, useSuspenseQuery, keepPreviousData } from '@tanstack/react-query';
 import { api } from '@/lib/api-client';
 import { QueryConfig } from '@/lib/react-query';
-import { ImportJob } from '@/types/api';
+import { ImportJobSummary } from '@/types/api';
 
 export interface Pagination {
   currentPage: number;
@@ -11,7 +11,7 @@ export interface Pagination {
 }
 
 export interface ImportJobsResponse {
-  importJobs: ImportJob[];
+  importJobs: ImportJobSummary[];
   pagination: Pagination;
 }
 

--- a/app/frontend/src/features/import-jobs/api/get-queue-activity.ts
+++ b/app/frontend/src/features/import-jobs/api/get-queue-activity.ts
@@ -1,0 +1,27 @@
+import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api-client';
+import { QueryConfig } from '@/lib/react-query';
+import { QueueActivity } from '@/types/api';
+
+export const getQueueActivity = async (): Promise<{ queueActivity: QueueActivity }> => {
+  const res = await api.get<{ queueActivity: QueueActivity }>('/import_jobs/queue_activity');
+  return res;
+};
+
+export const getQueueActivityQueryOptions = () => {
+  return queryOptions({
+    queryKey: ['queue-activity'],
+    queryFn: getQueueActivity,
+  });
+};
+
+type UseQueueActivityOptions = {
+  queryConfig?: QueryConfig<typeof getQueueActivityQueryOptions>;
+};
+
+export const useQueueActivitySuspenseQuery = ({ queryConfig }: UseQueueActivityOptions = {}) => {
+  return useSuspenseQuery({
+    ...getQueueActivityQueryOptions(),
+    ...queryConfig,
+  });
+};

--- a/app/frontend/src/features/import-jobs/api/validate-import-job.ts
+++ b/app/frontend/src/features/import-jobs/api/validate-import-job.ts
@@ -2,16 +2,18 @@ import { useMutation } from '@tanstack/react-query';
 import { api } from '@/lib/api-client';
 import { MutationConfig } from '@/lib/react-query';
 
+export type ValidateImportJobInput = {
+  data: { file: File; priority: string };
+};
+
 export const validateImportJob = ({
   data,
-}: {
-  data: { file: File; priority: string };
-}): Promise<{ importJob: any }> => {
+}: ValidateImportJobInput): Promise<{ valid: boolean; message: string }> => {
   const formData = new FormData();
   formData.append('import_file', data.file);
-  formData.append('import_job[priority]', data.priority);
+  formData.append('priority', data.priority);
 
-  return api.post(`/import_jobs/validate`, formData);
+  return api.post('/import_jobs/validate', formData);
 };
 
 type UseValidateImportJobOptions = {

--- a/app/frontend/src/features/import-jobs/api/validate-import-job.ts
+++ b/app/frontend/src/features/import-jobs/api/validate-import-job.ts
@@ -1,0 +1,26 @@
+import { useMutation } from '@tanstack/react-query';
+import { api } from '@/lib/api-client';
+import { MutationConfig } from '@/lib/react-query';
+
+export const validateImportJob = ({
+  data,
+}: {
+  data: { file: File; priority: string };
+}): Promise<{ importJob: any }> => {
+  const formData = new FormData();
+  formData.append('import_file', data.file);
+  formData.append('import_job[priority]', data.priority);
+
+  return api.post(`/import_jobs/validate`, formData);
+};
+
+type UseValidateImportJobOptions = {
+  mutationConfig?: MutationConfig<typeof validateImportJob>;
+};
+
+export const useValidateImportJob = ({ mutationConfig }: UseValidateImportJobOptions = {}) => {
+  return useMutation({
+    mutationFn: validateImportJob,
+    ...mutationConfig,
+  });
+};

--- a/app/frontend/src/features/import-jobs/components/delete-import-job-modal.tsx
+++ b/app/frontend/src/features/import-jobs/components/delete-import-job-modal.tsx
@@ -1,0 +1,89 @@
+import { Button, Modal, Alert } from 'react-bootstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { useNotifications } from '@/stores/notifications-store';
+import { useDeleteImportJob } from '../api/delete-import-job';
+
+type DeleteImportJobModalProps = {
+  show: boolean;
+  onHide: () => void;
+  importJobId: string;
+  importJobName: string;
+};
+
+// TODO: This component is very similar to DeletePublishTargetModal
+// When we refactor the delete modals to be more generic, we can combine them into a single component.
+export const DeleteImportJobModal = ({
+  show,
+  onHide,
+  importJobId,
+  importJobName,
+}: DeleteImportJobModalProps) => {
+  const addNotification = useNotifications((state) => state.addNotification);
+
+  const deleteImportJobMutation = useDeleteImportJob({
+    mutationConfig: {
+      onSuccess: () => {
+        addNotification({
+          type: 'success',
+          title: 'Import job deleted',
+          message: `"${importJobName}" was successfully deleted.`,
+        });
+        onHide();
+      },
+    },
+  });
+
+  const apiError = deleteImportJobMutation.error?.response?.errors?.base?.[0];
+
+  const handleHide = () => {
+    if (deleteImportJobMutation.isPending) return;
+    deleteImportJobMutation.reset();
+    onHide();
+  };
+
+  const handleConfirm = () => {
+    deleteImportJobMutation.mutate({ importJobId: importJobId });
+  };
+
+  return (
+    <Modal show={show} onHide={handleHide}>
+      <Modal.Header closeButton className="bg-danger-subtle border-danger border-opacity-25">
+        <Modal.Title className="text-danger-emphasis d-flex align-items-center gap-2 fs-5">
+          <FontAwesomeIcon icon={faTriangleExclamation} />
+          Delete Import Job
+        </Modal.Title>
+      </Modal.Header>
+
+      <Modal.Body>
+        <p className="mb-0">
+          Are you sure you want to delete <strong>{importJobName}</strong>? This action cannot be
+          undone.
+        </p>
+
+        {apiError && (
+          <Alert variant="danger" className="mb-0 mt-3 py-2">
+            <strong>Could not delete:</strong> {apiError}
+          </Alert>
+        )}
+      </Modal.Body>
+
+      <Modal.Footer>
+        <Button
+          variant="outline-secondary"
+          onClick={handleHide}
+          disabled={deleteImportJobMutation.isPending}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="danger"
+          onClick={handleConfirm}
+          disabled={deleteImportJobMutation.isPending}
+        >
+          {deleteImportJobMutation.isPending ? 'Deleting…' : 'Delete'}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};

--- a/app/frontend/src/features/import-jobs/components/import-error-alert.tsx
+++ b/app/frontend/src/features/import-jobs/components/import-error-alert.tsx
@@ -1,0 +1,51 @@
+import { Alert } from 'react-bootstrap';
+
+interface ImportErrorAlertProps {
+  errors?: Record<string, string[]>; // Field errors: `{ field: [messages] }`
+  title?: string;
+}
+
+// Converts field keys like "invalidCsvHeader" to "Invalid csv header"
+function humanize(key: string): string {
+  const text = key.replace(/([a-z0-9])([A-Z])/g, '$1 $2').toLowerCase();
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+// Alert displaying errors from a failed import or validation, grouped by key under one heading per key.
+export const ImportErrorAlert = ({ errors, title }: ImportErrorAlertProps) => {
+  if (!errors) return null;
+
+  const groups = Object.entries(errors).filter(([, messages]) => messages?.length);
+
+  // The request failed but didn't contain structured messages (eg. a 500 error)
+  if (groups.length === 0) {
+    return (
+      <Alert variant="danger" className="mb-4">
+        Something went wrong while processing your request. Please try again.
+      </Alert>
+    );
+  }
+
+  const totalCount = groups.reduce((sum, [, messages]) => sum + messages.length, 0);
+  const heading =
+    title ??
+    `${totalCount} ${totalCount === 1 ? 'error' : 'errors'} prevented this import from being saved`;
+
+  return (
+    <Alert variant="danger" className="mb-4">
+      <Alert.Heading as="h2" className="h6 mb-3">
+        {heading}
+      </Alert.Heading>
+      {groups.map(([key, messages]) => (
+        <div key={key} className="mb-2">
+          {key !== 'base' && <div className="fw-semibold">{humanize(key)}</div>}
+          <ul className="mb-0 ps-3">
+            {messages.map((message, index) => (
+              <li key={`${key}-${index}`}>{message}</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </Alert>
+  );
+};

--- a/app/frontend/src/features/import-jobs/components/import-job-detail.tsx
+++ b/app/frontend/src/features/import-jobs/components/import-job-detail.tsx
@@ -38,7 +38,7 @@ export const ImportJobDetail = ({ importJob }: ImportJobDetailProps) => {
           <dt className="fw-semibold text-secondary small text-uppercase mb-1">
             Restore archived S3 objects for new assets
           </dt>
-          <dd className="mb-0">TODO</dd>
+          <dd className="mb-0">{importJob.restoreArchivedS3ObjectsForNewAssets ? 'Yes' : 'No'}</dd>
         </div>
 
         <div className="mb-3">

--- a/app/frontend/src/features/import-jobs/components/import-job-detail.tsx
+++ b/app/frontend/src/features/import-jobs/components/import-job-detail.tsx
@@ -1,7 +1,11 @@
-import { Table as BTable } from 'react-bootstrap';
+import { Table as BTable, Button } from 'react-bootstrap';
 import { Link } from 'react-router';
 import { ImportJob } from '@/types/api';
 import { formatLocalDateTime } from '@/utils/format';
+import {
+  getCsvWithoutSuccessfulRowsDownloadUrl,
+  getOriginalCsvDownloadUrl,
+} from '../api/download-csv';
 
 interface ImportJobDetailProps {
   importJob: ImportJob;
@@ -41,27 +45,41 @@ export const ImportJobDetail = ({ importJob }: ImportJobDetailProps) => {
           <dd className="mb-0">{importJob.restoreArchivedS3ObjectsForNewAssets ? 'Yes' : 'No'}</dd>
         </div>
 
-        <div className="mb-3">
-          <dt className="fw-semibold text-secondary small text-uppercase mb-1">
-            Download Original CSV File
-          </dt>
-          <dd className="mb-0">
-            {/* <a href={importJob.originalCsvUrl} download>
-            Download
-          </a> */}
-          </dd>
-        </div>
+        {importJob.pathToCsvFile && (
+          <>
+            <div className="mb-3">
+              <dt className="fw-semibold text-secondary small text-uppercase mb-1">
+                Download Original CSV File
+              </dt>
+              <dd className="mb-0">
+                <Button
+                  as="a"
+                  href={getOriginalCsvDownloadUrl(importJob.id)}
+                  variant="link"
+                  className="p-0"
+                >
+                  Download
+                </Button>
+              </dd>
+            </div>
 
-        <div className="mb-3">
-          <dt className="fw-semibold text-secondary small text-uppercase mb-1">
-            Download CSV File Without Successful Rows
-          </dt>
-          <dd className="mb-0">
-            {/* <a href={importJob.csvWithoutSuccessfulRowsUrl} download>
-            Download
-          </a> */}
-          </dd>
-        </div>
+            <div className="mb-3">
+              <dt className="fw-semibold text-secondary small text-uppercase mb-1">
+                Download CSV File Without Successful Rows
+              </dt>
+              <dd className="mb-0">
+                <Button
+                  as="a"
+                  href={getCsvWithoutSuccessfulRowsDownloadUrl(importJob.id)}
+                  variant="link"
+                  className="p-0"
+                >
+                  Download
+                </Button>
+              </dd>
+            </div>
+          </>
+        )}
       </div>
 
       <BTable striped bordered responsive>

--- a/app/frontend/src/features/import-jobs/components/import-job-detail.tsx
+++ b/app/frontend/src/features/import-jobs/components/import-job-detail.tsx
@@ -1,6 +1,7 @@
-import { ImportJob } from '@/types/api';
 import { Table as BTable } from 'react-bootstrap';
 import { Link } from 'react-router';
+import { ImportJob } from '@/types/api';
+import { formatLocalDateTime } from '@/utils/format';
 
 interface ImportJobDetailProps {
   importJob: ImportJob;
@@ -18,7 +19,7 @@ export const ImportJobDetail = ({ importJob }: ImportJobDetailProps) => {
       <div className="mb-4">
         <div className="mb-3">
           <dt className="fw-semibold text-secondary small text-uppercase mb-1">Created on</dt>
-          <dd className="mb-0">{importJob.createdAt}</dd>
+          <dd className="mb-0">{formatLocalDateTime(importJob.createdAt)}</dd>
         </div>
 
         <div className="mb-3">
@@ -33,7 +34,6 @@ export const ImportJobDetail = ({ importJob }: ImportJobDetailProps) => {
           <dd className="mb-0">{importJob.priority}</dd>
         </div>
 
-        {/* TODO: Include restore_archived_s3_objects_for_new_assets boolean */}
         <div className="mb-3">
           <dt className="fw-semibold text-secondary small text-uppercase mb-1">
             Restore archived S3 objects for new assets

--- a/app/frontend/src/features/import-jobs/components/import-job-detail.tsx
+++ b/app/frontend/src/features/import-jobs/components/import-job-detail.tsx
@@ -1,5 +1,5 @@
 import { ImportJob } from '@/types/api';
-import { Table as BTable } from 'react-bootstrap';
+import { Table as BTable, Card, Col, Row } from 'react-bootstrap';
 import { Link } from 'react-router';
 
 interface ImportJobDetailProps {
@@ -9,7 +9,10 @@ interface ImportJobDetailProps {
 export const ImportJobDetail = ({ importJob }: ImportJobDetailProps) => {
   return (
     <div>
-      <h2>{importJob.name}</h2>
+      <div className="d-flex align-items-center gap-2 mb-4">
+        <h2 className="mb-0">{importJob.name}</h2>
+        <span className="text-muted">#{importJob.id}</span>
+      </div>
 
       {/* TODO: Extract into separate components */}
       <div className="mb-4">
@@ -20,12 +23,22 @@ export const ImportJobDetail = ({ importJob }: ImportJobDetailProps) => {
 
         <div className="mb-3">
           <dt className="fw-semibold text-secondary small text-uppercase mb-1">User</dt>
-          <dd className="mb-0">{importJob.user.fullName}</dd>
+          <dd className="mb-0">
+            {importJob.user.fullName} ({importJob.user.uid})
+          </dd>
         </div>
 
         <div className="mb-3">
-          <dt className="fw-semibold text-secondary small text-uppercase mb-1">Email</dt>
-          <dd className="mb-0">{importJob.user.email}</dd>
+          <dt className="fw-semibold text-secondary small text-uppercase mb-1">Priority</dt>
+          <dd className="mb-0">{importJob.priority}</dd>
+        </div>
+
+        {/* TODO: Include restore_archived_s3_objects_for_new_assets boolean */}
+        <div className="mb-3">
+          <dt className="fw-semibold text-secondary small text-uppercase mb-1">
+            Restore archived S3 objects for new assets
+          </dt>
+          <dd className="mb-0">TODO</dd>
         </div>
 
         <div className="mb-3">

--- a/app/frontend/src/features/import-jobs/components/import-job-detail.tsx
+++ b/app/frontend/src/features/import-jobs/components/import-job-detail.tsx
@@ -51,7 +51,7 @@ export const ImportJobDetail = ({ importJob }: ImportJobDetailProps) => {
         </div>
       </div>
 
-      <BTable striped bordered hover responsive>
+      <BTable striped bordered responsive>
         <thead>
           <tr>
             <th>Pending rows</th>

--- a/app/frontend/src/features/import-jobs/components/import-job-detail.tsx
+++ b/app/frontend/src/features/import-jobs/components/import-job-detail.tsx
@@ -1,5 +1,6 @@
 import { ImportJob } from '@/types/api';
 import { Table as BTable } from 'react-bootstrap';
+import { Link } from 'react-router';
 
 interface ImportJobDetailProps {
   importJob: ImportJob;
@@ -64,7 +65,14 @@ export const ImportJobDetail = ({ importJob }: ImportJobDetailProps) => {
             <td>{importJob.pendingCount}</td>
             <td>{importJob.successCount}</td>
             <td>{importJob.failureCount}</td>
-            <td>{importJob.pendingCount + importJob.successCount + importJob.failureCount}</td>
+            <td>
+              <Link
+                to={{ pathname: `digital-object-imports` }}
+                className="link-underline link-underline-opacity-0 link-underline-opacity-75-hover"
+              >
+                {importJob.pendingCount + importJob.successCount + importJob.failureCount}
+              </Link>
+            </td>
           </tr>
         </tbody>
       </BTable>

--- a/app/frontend/src/features/import-jobs/components/import-job-detail.tsx
+++ b/app/frontend/src/features/import-jobs/components/import-job-detail.tsx
@@ -1,9 +1,73 @@
-export const ImportJobDetail = ({ importJob }: { importJob: any }) => {
+import { ImportJob } from '@/types/api';
+import { Table as BTable } from 'react-bootstrap';
+
+interface ImportJobDetailProps {
+  importJob: ImportJob;
+}
+
+export const ImportJobDetail = ({ importJob }: ImportJobDetailProps) => {
   return (
     <div>
-      <h1>{importJob.id}</h1>
-      <p>Status: {importJob.status}</p>
-      <p>Priority: {importJob.priority}</p>
+      <h2>{importJob.name}</h2>
+
+      {/* TODO: Extract into separate components */}
+      <div className="mb-4">
+        <div className="mb-3">
+          <dt className="fw-semibold text-secondary small text-uppercase mb-1">Created on</dt>
+          <dd className="mb-0">{importJob.createdAt}</dd>
+        </div>
+
+        <div className="mb-3">
+          <dt className="fw-semibold text-secondary small text-uppercase mb-1">User</dt>
+          <dd className="mb-0">{importJob.user.fullName}</dd>
+        </div>
+
+        <div className="mb-3">
+          <dt className="fw-semibold text-secondary small text-uppercase mb-1">Email</dt>
+          <dd className="mb-0">{importJob.user.email}</dd>
+        </div>
+
+        <div className="mb-3">
+          <dt className="fw-semibold text-secondary small text-uppercase mb-1">
+            Download Original CSV File
+          </dt>
+          <dd className="mb-0">
+            {/* <a href={importJob.originalCsvUrl} download>
+            Download
+          </a> */}
+          </dd>
+        </div>
+
+        <div className="mb-3">
+          <dt className="fw-semibold text-secondary small text-uppercase mb-1">
+            Download CSV File Without Successful Rows
+          </dt>
+          <dd className="mb-0">
+            {/* <a href={importJob.csvWithoutSuccessfulRowsUrl} download>
+            Download
+          </a> */}
+          </dd>
+        </div>
+      </div>
+
+      <BTable striped bordered hover responsive>
+        <thead>
+          <tr>
+            <th>Pending rows</th>
+            <th>Successful row imports</th>
+            <th>Failed row imports</th>
+            <th>Total number of rows</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>{importJob.pendingCount}</td>
+            <td>{importJob.successCount}</td>
+            <td>{importJob.failureCount}</td>
+            <td>{importJob.pendingCount + importJob.successCount + importJob.failureCount}</td>
+          </tr>
+        </tbody>
+      </BTable>
     </div>
   );
 };

--- a/app/frontend/src/features/import-jobs/components/import-job-detail.tsx
+++ b/app/frontend/src/features/import-jobs/components/import-job-detail.tsx
@@ -1,5 +1,5 @@
 import { ImportJob } from '@/types/api';
-import { Table as BTable, Card, Col, Row } from 'react-bootstrap';
+import { Table as BTable } from 'react-bootstrap';
 import { Link } from 'react-router';
 
 interface ImportJobDetailProps {

--- a/app/frontend/src/features/import-jobs/components/import-job-detail.tsx
+++ b/app/frontend/src/features/import-jobs/components/import-job-detail.tsx
@@ -1,0 +1,9 @@
+export const ImportJobDetail = ({ importJob }: { importJob: any }) => {
+  return (
+    <div>
+      <h1>{importJob.id}</h1>
+      <p>Status: {importJob.status}</p>
+      <p>Priority: {importJob.priority}</p>
+    </div>
+  );
+};

--- a/app/frontend/src/features/import-jobs/components/import-job-detail.tsx
+++ b/app/frontend/src/features/import-jobs/components/import-job-detail.tsx
@@ -1,4 +1,4 @@
-import { Table as BTable, Button } from 'react-bootstrap';
+import { Table as BTable, Button, Badge, Card, Row, Col } from 'react-bootstrap';
 import { Link } from 'react-router';
 import { ImportJob } from '@/types/api';
 import { formatLocalDateTime } from '@/utils/format';
@@ -11,102 +11,136 @@ interface ImportJobDetailProps {
   importJob: ImportJob;
 }
 
+const statusVariant = (status: string): string =>
+  ({
+    'successfully completed': 'success',
+    'complete with failures': 'warning',
+    incomplete: 'secondary',
+  })[status?.toLowerCase()] ?? 'secondary';
+
 export const ImportJobDetail = ({ importJob }: ImportJobDetailProps) => {
+  const { pendingCount, successCount, failureCount } = importJob;
+  const totalCount = pendingCount + successCount + failureCount;
+
+  const stats = [
+    { label: 'Successful', count: successCount, variant: 'success', filterName: 'success' },
+    { label: 'Pending', count: pendingCount, variant: 'secondary', filterName: 'pending' },
+    { label: 'Failed', count: failureCount, variant: 'danger', filterName: 'failure' },
+  ];
+
   return (
     <div>
-      <div className="d-flex align-items-center gap-2 mb-4">
+      <div className="d-flex align-items-center gap-2 mb-2">
         <h2 className="mb-0">{importJob.name}</h2>
         <span className="text-muted">#{importJob.id}</span>
+        <Badge bg={statusVariant(importJob.status)} className="ms-auto text-uppercase">
+          {importJob.status}
+        </Badge>
       </div>
 
-      {/* TODO: Extract into separate components */}
-      <div className="mb-4">
-        <div className="mb-3">
-          <dt className="fw-semibold text-secondary small text-uppercase mb-1">Created on</dt>
-          <dd className="mb-0">{formatLocalDateTime(importJob.createdAt)}</dd>
-        </div>
-
-        <div className="mb-3">
-          <dt className="fw-semibold text-secondary small text-uppercase mb-1">User</dt>
-          <dd className="mb-0">
-            {importJob.user.fullName} ({importJob.user.uid})
-          </dd>
-        </div>
-
-        <div className="mb-3">
-          <dt className="fw-semibold text-secondary small text-uppercase mb-1">Priority</dt>
-          <dd className="mb-0">{importJob.priority}</dd>
-        </div>
-
-        <div className="mb-3">
-          <dt className="fw-semibold text-secondary small text-uppercase mb-1">
-            Restore archived S3 objects for new assets
-          </dt>
-          <dd className="mb-0">{importJob.restoreArchivedS3ObjectsForNewAssets ? 'Yes' : 'No'}</dd>
-        </div>
-
-        {importJob.pathToCsvFile && (
-          <>
-            <div className="mb-3">
-              <dt className="fw-semibold text-secondary small text-uppercase mb-1">
-                Download Original CSV File
-              </dt>
-              <dd className="mb-0">
-                <Button
-                  as="a"
-                  href={getOriginalCsvDownloadUrl(importJob.id)}
-                  variant="link"
-                  className="p-0"
-                >
-                  Download
-                </Button>
-              </dd>
-            </div>
-
-            <div className="mb-3">
-              <dt className="fw-semibold text-secondary small text-uppercase mb-1">
-                Download CSV File Without Successful Rows
-              </dt>
-              <dd className="mb-0">
-                <Button
-                  as="a"
-                  href={getCsvWithoutSuccessfulRowsDownloadUrl(importJob.id)}
-                  variant="link"
-                  className="p-0"
-                >
-                  Download
-                </Button>
-              </dd>
-            </div>
-          </>
-        )}
+      <div className="d-flex flex-wrap gap-4 text-muted small border-bottom pb-3 mb-4">
+        <span>
+          Uploaded{' '}
+          <span className="text-body fw-semibold">{formatLocalDateTime(importJob.createdAt)}</span>
+        </span>
+        <span>
+          by <span className="text-body fw-semibold">{importJob.user.fullName}</span> (
+          {importJob.user.uid})
+        </span>
+        <span>
+          Priority{' '}
+          <span className="text-body fw-semibold text-capitalize">{importJob.priority}</span>
+        </span>
       </div>
 
-      <BTable striped bordered responsive>
-        <thead>
-          <tr>
-            <th>Pending rows</th>
-            <th>Successful row imports</th>
-            <th>Failed row imports</th>
-            <th>Total number of rows</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>{importJob.pendingCount}</td>
-            <td>{importJob.successCount}</td>
-            <td>{importJob.failureCount}</td>
-            <td>
-              <Link
-                to={{ pathname: `digital-object-imports` }}
-                className="link-underline link-underline-opacity-0 link-underline-opacity-75-hover"
-              >
-                {importJob.pendingCount + importJob.successCount + importJob.failureCount}
-              </Link>
-            </td>
-          </tr>
-        </tbody>
-      </BTable>
+      <Card className="mb-4">
+        <Card.Body>
+          <Card.Title as="h5" className="mb-3">
+            Job details
+          </Card.Title>
+          <BTable borderless responsive className="mb-0 align-middle">
+            <tbody>
+              <tr>
+                <th className="text-secondary small text-uppercase fw-semibold w-50 w-md-25">
+                  Restore archived S3 objects for new assets
+                </th>
+                <td>{importJob.restoreArchivedS3ObjectsForNewAssets ? 'Yes' : 'No'}</td>
+              </tr>
+              {importJob.pathToCsvFile && (
+                <>
+                  <tr>
+                    <th className="text-secondary small text-uppercase fw-semibold">
+                      Original CSV file
+                    </th>
+                    <td>
+                      <Button
+                        as="a"
+                        href={getOriginalCsvDownloadUrl(importJob.id)}
+                        variant="link"
+                        className="p-0"
+                      >
+                        Download
+                      </Button>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th className="text-secondary small text-uppercase fw-semibold">
+                      CSV without successful rows
+                    </th>
+                    <td>
+                      <Button
+                        as="a"
+                        href={getCsvWithoutSuccessfulRowsDownloadUrl(importJob.id)}
+                        variant="link"
+                        className="p-0"
+                      >
+                        Download
+                      </Button>
+                    </td>
+                  </tr>
+                </>
+              )}
+            </tbody>
+          </BTable>
+        </Card.Body>
+      </Card>
+
+      <Card className="mb-4">
+        <Card.Body>
+          <div className="d-flex justify-content-between align-items-baseline mb-3">
+            <Card.Title as="h5" className="mb-0">
+              Row imports
+            </Card.Title>
+            <Link
+              to={{ pathname: 'digital-object-imports' }}
+              className="small link-underline link-underline-opacity-0 link-underline-opacity-75-hover"
+            >
+              View all {totalCount} rows
+            </Link>
+          </div>
+
+          <Row className="g-3 text-center">
+            {stats.map(({ label, count, variant, filterName }) => (
+              <Col xs={4} key={label}>
+                <Link
+                  to={{
+                    pathname: 'digital-object-imports',
+                    search: `?status=${filterName}`,
+                  }}
+                  className="text-decoration-none"
+                >
+                  <Card className="h-100 border-0 bg-light">
+                    <Card.Body className="py-3">
+                      <div className={`fs-3 fw-bold text-${variant}`}>{count}</div>
+                      <div className="text-muted small text-uppercase">{label}</div>
+                    </Card.Body>
+                  </Card>
+                </Link>
+              </Col>
+            ))}
+          </Row>
+        </Card.Body>
+      </Card>
     </div>
   );
 };

--- a/app/frontend/src/features/import-jobs/components/import-job-form.tsx
+++ b/app/frontend/src/features/import-jobs/components/import-job-form.tsx
@@ -22,7 +22,7 @@ export const ImportJobForm = () => {
 
   const [formData, setFormData] = useState<ImportJobFormData>({
     file: null,
-    priority: 'low',
+    priority: 'medium',
     restoreArchivedS3ObjectsForNewAssets: false,
   });
 

--- a/app/frontend/src/features/import-jobs/components/import-job-form.tsx
+++ b/app/frontend/src/features/import-jobs/components/import-job-form.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+import { Button, Col, Form, Row } from 'react-bootstrap';
+import { Input, Select } from '@/components/ui/form';
+import { useCreateImportJob } from '@/features/import-jobs/api/create-import-job';
+import { useNotifications } from '@/stores/notifications-store';
+import { useNavigate } from 'react-router';
+
+export const ImportJobForm = () => {
+  const navigate = useNavigate();
+  const { addNotification } = useNotifications();
+  const [formData, setFormData] = useState<{
+    file: File | null;
+    priority: string;
+  }>({
+    file: null,
+    priority: 'low',
+  });
+
+  const createJobImportMutation = useCreateImportJob({
+    mutationConfig: {
+      onSuccess: (data) => {
+        addNotification({
+          type: 'success',
+          title: 'Import job created',
+        });
+        navigate(`/import-jobs/${data.importJob.id}`);
+      },
+    },
+  });
+
+  // const fieldErrors: Record<string, string> = {};
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    console.log('Submitting values', formData);
+    if (formData.file) {
+      createJobImportMutation.mutate({
+        data: { file: formData.file, priority: formData.priority },
+      });
+    }
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] ?? null;
+    setFormData((prev) => ({ ...prev, file }));
+  };
+
+  const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  // TODO: Display validation errors
+  return (
+    <Form onSubmit={handleSubmit} className="mb-8">
+      <Row className="mb-3">
+        {/* ? Add limits to what file types can be uploaded */}
+
+        <Input
+          label="File"
+          type="file"
+          onChange={handleFileChange}
+          // error={fieldErrors.file}
+          name="file"
+          md={7}
+          required
+        />
+      </Row>
+      <Row className="mb-3">
+        <Select
+          label="Priority"
+          name="priority"
+          value={formData.priority}
+          onChange={handleSelectChange}
+          md={7}
+          // error={fieldErrors.priority}
+        >
+          <option value="low">Low</option>
+          <option value="medium">Medium</option>
+          <option value="high">High</option>
+        </Select>
+      </Row>
+
+      {/* TODO: Ability to validate job import without uploading */}
+      <Row className="mb-4 mt-2">
+        <Col md={7}>
+          <Button
+            variant="primary"
+            type="submit"
+            disabled={createJobImportMutation.isPending}
+            className="px-3"
+          >
+            {createJobImportMutation.isPending ? 'Saving...' : 'Create a New Import Job'}
+          </Button>
+        </Col>
+      </Row>
+    </Form>
+  );
+};

--- a/app/frontend/src/features/import-jobs/components/import-job-form.tsx
+++ b/app/frontend/src/features/import-jobs/components/import-job-form.tsx
@@ -1,100 +1,181 @@
 import { useState } from 'react';
-import { Button, Col, Form, Row } from 'react-bootstrap';
+import { Alert, Button, Col, Form, Row } from 'react-bootstrap';
+import { useNavigate } from 'react-router';
+
 import { Input, Select } from '@/components/ui/form';
 import { useCreateImportJob } from '@/features/import-jobs/api/create-import-job';
+import { useValidateImportJob } from '@/features/import-jobs/api/validate-import-job';
+import { ImportErrorAlert } from '@/features/import-jobs/components/import-error-alert';
 import { useNotifications } from '@/stores/notifications-store';
-import { useNavigate } from 'react-router';
+
+type Priority = 'low' | 'medium' | 'high';
+
+interface ImportJobFormData {
+  file: File | null;
+  priority: Priority;
+  restoreArchivedS3ObjectsForNewAssets: boolean;
+}
 
 export const ImportJobForm = () => {
   const navigate = useNavigate();
   const { addNotification } = useNotifications();
-  const [formData, setFormData] = useState<{
-    file: File | null;
-    priority: string;
-  }>({
+
+  const [formData, setFormData] = useState<ImportJobFormData>({
     file: null,
     priority: 'low',
+    restoreArchivedS3ObjectsForNewAssets: false,
   });
 
-  const createJobImportMutation = useCreateImportJob({
+  // Errors from a create OR validate request, grouped by their field key
+  const [apiErrors, setApiErrors] = useState<Record<string, string[]> | undefined>(undefined);
+  // Inline success banner shown after a passing "Validate Only" run
+  const [validationPassed, setValidationPassed] = useState(false);
+
+  const resetFeedback = () => {
+    setApiErrors(undefined);
+    setValidationPassed(false);
+  };
+
+  const createImportJobMutation = useCreateImportJob({
     mutationConfig: {
       onSuccess: (data) => {
-        addNotification({
-          type: 'success',
-          title: 'Import job created',
-        });
+        resetFeedback();
+        addNotification({ type: 'success', title: 'Import job created' });
         navigate(`/import-jobs/${data.importJob.id}`);
+      },
+      onError: (error) => {
+        setValidationPassed(false);
+        setApiErrors(error.response?.errors ?? {});
       },
     },
   });
 
-  // const fieldErrors: Record<string, string> = {};
+  const validateImportJobMutation = useValidateImportJob({
+    mutationConfig: {
+      onSuccess: () => {
+        setApiErrors(undefined);
+        setValidationPassed(true);
+        addNotification({
+          type: 'success',
+          title: 'The submitted CSV file appears to be valid.',
+        });
+      },
+      onError: (error) => {
+        setValidationPassed(false);
+        setApiErrors(error.response?.errors ?? {});
+      },
+    },
+  });
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const isSubmitting = createImportJobMutation.isPending || validateImportJobMutation.isPending;
+
+  const handleCreate = (e: React.FormEvent) => {
     e.preventDefault();
+    if (!formData.file) return;
 
-    console.log('Submitting values', formData);
-    if (formData.file) {
-      createJobImportMutation.mutate({
-        data: { file: formData.file, priority: formData.priority },
-      });
-    }
+    resetFeedback();
+    createImportJobMutation.mutate({
+      data: {
+        file: formData.file,
+        priority: formData.priority,
+        restoreArchivedS3ObjectsForNewAssets: formData.restoreArchivedS3ObjectsForNewAssets,
+      },
+    });
+  };
+
+  const handleValidate = () => {
+    if (!formData.file) return;
+
+    resetFeedback();
+    validateImportJobMutation.mutate({
+      data: { file: formData.file, priority: formData.priority },
+    });
   };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0] ?? null;
+    resetFeedback();
     setFormData((prev) => ({ ...prev, file }));
   };
 
-  const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const { name, value } = e.target;
-    setFormData((prev) => ({ ...prev, [name]: value }));
+  const handlePriorityChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setFormData((prev) => ({ ...prev, priority: e.target.value as Priority }));
   };
 
-  // TODO: Display validation errors
   return (
-    <Form onSubmit={handleSubmit} className="mb-8">
-      <Row className="mb-3">
-        {/* ? Add limits to what file types can be uploaded */}
-
-        <Input
-          label="File"
-          type="file"
-          onChange={handleFileChange}
-          // error={fieldErrors.file}
-          name="file"
-          md={7}
-          required
-        />
-      </Row>
-      <Row className="mb-3">
-        <Select
-          label="Priority"
-          name="priority"
-          value={formData.priority}
-          onChange={handleSelectChange}
-          md={7}
-          // error={fieldErrors.priority}
+    <>
+      {validationPassed && (
+        <Alert
+          variant="success"
+          className="mb-4"
+          dismissible
+          onClose={() => setValidationPassed(false)}
         >
-          <option value="low">Low</option>
-          <option value="medium">Medium</option>
-          <option value="high">High</option>
-        </Select>
-      </Row>
+          The submitted CSV file appears to be valid.
+        </Alert>
+      )}
 
-      {/* TODO: Ability to validate job import without uploading */}
-      <Row className="mb-4 mt-2">
-        <Col md={7}>
-          <Button
-            variant="primary"
-            type="submit"
-            disabled={createJobImportMutation.isPending}
-            className="px-3"
+      <ImportErrorAlert errors={apiErrors} />
+
+      <Form onSubmit={handleCreate} className="mb-4" noValidate>
+        <Row className="mb-3">
+          {/* ? Add limits to what file types can be uploaded */}
+          <Input label="File" type="file" onChange={handleFileChange} name="file" md={7} required />
+        </Row>
+        <Row className="mb-3">
+          <Select
+            label="Priority"
+            name="priority"
+            value={formData.priority}
+            onChange={handlePriorityChange}
+            md={7}
           >
-            {createJobImportMutation.isPending ? 'Saving...' : 'Create a New Import Job'}
-          </Button>
-        </Col>
-      </Row>
-    </Form>
+            <option value="low">Low</option>
+            <option value="medium">Medium</option>
+            <option value="high">High</option>
+          </Select>
+        </Row>
+        <Row className="mb-3">
+          <Col md={7}>
+            <Form.Check
+              type="checkbox"
+              id="restoreArchivedS3ObjectsForNewAssets"
+              label="Restore archived S3 objects for new assets"
+              name="restoreArchivedS3ObjectsForNewAssets"
+              checked={formData.restoreArchivedS3ObjectsForNewAssets}
+              onChange={(e) =>
+                setFormData((prev) => ({
+                  ...prev,
+                  restoreArchivedS3ObjectsForNewAssets: e.target.checked,
+                }))
+              }
+            />
+          </Col>
+        </Row>
+
+        <Row className="mb-4 mt-2">
+          <Col md={7} className="d-flex gap-2">
+            <Button
+              variant="primary"
+              type="submit"
+              disabled={isSubmitting || !formData.file}
+              className="px-3"
+            >
+              {createImportJobMutation.isPending ? 'Saving…' : 'Create a New Import Job'}
+            </Button>
+
+            <Button
+              variant="outline-secondary"
+              type="button"
+              onClick={handleValidate}
+              disabled={isSubmitting || !formData.file}
+              className="px-3"
+            >
+              {validateImportJobMutation.isPending ? 'Validating…' : 'Validate Only'}
+            </Button>
+          </Col>
+        </Row>
+      </Form>
+    </>
   );
 };

--- a/app/frontend/src/features/import-jobs/components/import-jobs-list.tsx
+++ b/app/frontend/src/features/import-jobs/components/import-jobs-list.tsx
@@ -7,10 +7,12 @@ import { columnDefs } from '../utils/import-jobs-list-column-defs';
 import { useImportJobsSuspenseQuery } from '../api/get-import-jobs';
 import { ImportJobSummary } from '@/types/api';
 import { DeleteImportJobModal } from './delete-import-job-modal';
+import { useCurrentUser } from '@/lib/auth';
 
 const ImportJobsList = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const page = Number(searchParams.get('page')) || 1;
+  const { data: currentUser } = useCurrentUser();
 
   const importJobsQuery = useImportJobsSuspenseQuery({ page });
   const { importJobs, pagination } = importJobsQuery.data;
@@ -40,7 +42,7 @@ const ImportJobsList = () => {
           onPaginationChange: handlePaginationChange,
           rowCount: pagination.totalCount,
         }}
-        meta={{ onDeleteRow: setJobToDelete }}
+        meta={{ currentUser: currentUser ?? undefined, onDeleteRow: setJobToDelete }}
       />
 
       <DeleteImportJobModal

--- a/app/frontend/src/features/import-jobs/components/import-jobs-list.tsx
+++ b/app/frontend/src/features/import-jobs/components/import-jobs-list.tsx
@@ -1,15 +1,35 @@
-import type { ColumnDef } from '@tanstack/react-table';
+import { useState } from 'react';
+import { useSearchParams } from 'react-router';
+import type { ColumnDef, PaginationState } from '@tanstack/react-table';
 
 import TableBuilder from '@/components/ui/table-builder/table-builder';
 import { columnDefs } from '../utils/import-jobs-list-column-defs';
 import { useImportJobsSuspenseQuery } from '../api/get-import-jobs';
 import { ImportJob } from '@/types/api';
+// import { DeleteImportJobModal } from './delete-import-job-modal';
 
 const ImportJobsList = () => {
-  const importJobsQuery = useImportJobsSuspenseQuery();
-  const importJobs = importJobsQuery.data.importJobs;
+  const [searchParams] = useSearchParams();
+  const page = Number(searchParams.get('page')) || 1;
 
-  return <TableBuilder data={importJobs} columns={columnDefs as ColumnDef<ImportJob>[]} />;
+  const importJobsQuery = useImportJobsSuspenseQuery({ page });
+  const importJobs = importJobsQuery.data.importJobs;
+  const paginationData = importJobsQuery.data.pagination;
+  // console.log('importJobs:', importJobsQuery.data);
+
+  // const [pagination, setPagination] = useState<PaginationState>({
+  //   pageIndex: 0,
+  //   pageSize: paginationData.perPage,
+  // });
+
+  return (
+    <>
+      {/* <DeleteImportJobModal /> */}
+
+      {/* TODO: Modify TableBuilder to handle server-side pagination */}
+      <TableBuilder data={importJobs} columns={columnDefs as ColumnDef<ImportJob>[]} />
+    </>
+  );
 };
 
 export default ImportJobsList;

--- a/app/frontend/src/features/import-jobs/components/import-jobs-list.tsx
+++ b/app/frontend/src/features/import-jobs/components/import-jobs-list.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useSearchParams } from 'react-router';
 import type { ColumnDef, PaginationState, Updater } from '@tanstack/react-table';
 
@@ -5,6 +6,7 @@ import TableBuilder from '@/components/ui/table-builder/table-builder';
 import { columnDefs } from '../utils/import-jobs-list-column-defs';
 import { useImportJobsSuspenseQuery } from '../api/get-import-jobs';
 import { ImportJobSummary } from '@/types/api';
+import { DeleteImportJobModal } from './delete-import-job-modal';
 
 const ImportJobsList = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -13,7 +15,8 @@ const ImportJobsList = () => {
   const importJobsQuery = useImportJobsSuspenseQuery({ page });
   const { importJobs, pagination } = importJobsQuery.data;
 
-  // TanStack is zero-based; URL is one-based.
+  const [jobToDelete, setJobToDelete] = useState<ImportJobSummary | null>(null);
+
   const paginationState: PaginationState = {
     pageIndex: page - 1,
     pageSize: pagination.perPage,
@@ -29,8 +32,6 @@ const ImportJobsList = () => {
 
   return (
     <>
-      {/* <DeleteImportJobModal /> */}
-
       <TableBuilder
         data={importJobs}
         columns={columnDefs as ColumnDef<ImportJobSummary>[]}
@@ -39,6 +40,14 @@ const ImportJobsList = () => {
           onPaginationChange: handlePaginationChange,
           rowCount: pagination.totalCount,
         }}
+        meta={{ onDeleteRow: setJobToDelete }}
+      />
+
+      <DeleteImportJobModal
+        show={jobToDelete !== null}
+        onHide={() => setJobToDelete(null)}
+        importJobId={jobToDelete ? String(jobToDelete.id) : ''}
+        importJobName={jobToDelete?.name ?? ''}
       />
     </>
   );

--- a/app/frontend/src/features/import-jobs/components/import-jobs-list.tsx
+++ b/app/frontend/src/features/import-jobs/components/import-jobs-list.tsx
@@ -5,7 +5,7 @@ import type { ColumnDef, PaginationState } from '@tanstack/react-table';
 import TableBuilder from '@/components/ui/table-builder/table-builder';
 import { columnDefs } from '../utils/import-jobs-list-column-defs';
 import { useImportJobsSuspenseQuery } from '../api/get-import-jobs';
-import { ImportJob } from '@/types/api';
+import { ImportJobSummary } from '@/types/api';
 // import { DeleteImportJobModal } from './delete-import-job-modal';
 
 const ImportJobsList = () => {
@@ -27,7 +27,7 @@ const ImportJobsList = () => {
       {/* <DeleteImportJobModal /> */}
 
       {/* TODO: Modify TableBuilder to handle server-side pagination */}
-      <TableBuilder data={importJobs} columns={columnDefs as ColumnDef<ImportJob>[]} />
+      <TableBuilder data={importJobs} columns={columnDefs as ColumnDef<ImportJobSummary>[]} />
     </>
   );
 };

--- a/app/frontend/src/features/import-jobs/components/import-jobs-list.tsx
+++ b/app/frontend/src/features/import-jobs/components/import-jobs-list.tsx
@@ -33,7 +33,7 @@ const ImportJobsList = () => {
   };
 
   return (
-    <>
+    <div className="mt-4">
       <TableBuilder
         data={importJobs}
         columns={columnDefs as ColumnDef<ImportJobSummary>[]}
@@ -51,7 +51,7 @@ const ImportJobsList = () => {
         importJobId={jobToDelete ? String(jobToDelete.id) : ''}
         importJobName={jobToDelete?.name ?? ''}
       />
-    </>
+    </div>
   );
 };
 

--- a/app/frontend/src/features/import-jobs/components/import-jobs-list.tsx
+++ b/app/frontend/src/features/import-jobs/components/import-jobs-list.tsx
@@ -1,0 +1,15 @@
+import type { ColumnDef } from '@tanstack/react-table';
+
+import TableBuilder from '@/components/ui/table-builder/table-builder';
+import { columnDefs } from '../utils/import-jobs-list-column-defs';
+import { useImportJobsSuspenseQuery } from '../api/get-import-jobs';
+import { ImportJob } from '@/types/api';
+
+const ImportJobsList = () => {
+  const importJobsQuery = useImportJobsSuspenseQuery();
+  const importJobs = importJobsQuery.data.importJobs;
+
+  return <TableBuilder data={importJobs} columns={columnDefs as ColumnDef<ImportJob>[]} />;
+};
+
+export default ImportJobsList;

--- a/app/frontend/src/features/import-jobs/components/import-jobs-list.tsx
+++ b/app/frontend/src/features/import-jobs/components/import-jobs-list.tsx
@@ -1,33 +1,45 @@
-import { useState } from 'react';
 import { useSearchParams } from 'react-router';
-import type { ColumnDef, PaginationState } from '@tanstack/react-table';
+import type { ColumnDef, PaginationState, Updater } from '@tanstack/react-table';
 
 import TableBuilder from '@/components/ui/table-builder/table-builder';
 import { columnDefs } from '../utils/import-jobs-list-column-defs';
 import { useImportJobsSuspenseQuery } from '../api/get-import-jobs';
 import { ImportJobSummary } from '@/types/api';
-// import { DeleteImportJobModal } from './delete-import-job-modal';
 
 const ImportJobsList = () => {
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const page = Number(searchParams.get('page')) || 1;
 
   const importJobsQuery = useImportJobsSuspenseQuery({ page });
-  const importJobs = importJobsQuery.data.importJobs;
-  const paginationData = importJobsQuery.data.pagination;
-  // console.log('importJobs:', importJobsQuery.data);
+  const { importJobs, pagination } = importJobsQuery.data;
 
-  // const [pagination, setPagination] = useState<PaginationState>({
-  //   pageIndex: 0,
-  //   pageSize: paginationData.perPage,
-  // });
+  // TanStack is zero-based; URL is one-based.
+  const paginationState: PaginationState = {
+    pageIndex: page - 1,
+    pageSize: pagination.perPage,
+  };
+
+  const handlePaginationChange = (updater: Updater<PaginationState>) => {
+    const next = typeof updater === 'function' ? updater(paginationState) : updater;
+    setSearchParams((prev) => {
+      prev.set('page', String(next.pageIndex + 1));
+      return prev;
+    });
+  };
 
   return (
     <>
       {/* <DeleteImportJobModal /> */}
 
-      {/* TODO: Modify TableBuilder to handle server-side pagination */}
-      <TableBuilder data={importJobs} columns={columnDefs as ColumnDef<ImportJobSummary>[]} />
+      <TableBuilder
+        data={importJobs}
+        columns={columnDefs as ColumnDef<ImportJobSummary>[]}
+        pagination={{
+          state: paginationState,
+          onPaginationChange: handlePaginationChange,
+          rowCount: pagination.totalCount,
+        }}
+      />
     </>
   );
 };

--- a/app/frontend/src/features/import-jobs/components/queue-activity-display.tsx
+++ b/app/frontend/src/features/import-jobs/components/queue-activity-display.tsx
@@ -1,0 +1,25 @@
+import { QueueActivity } from '@/types/api';
+import { useQueueActivitySuspenseQuery } from '../api/get-queue-activity';
+
+export const QueueActivityDisplay = () => {
+  const { data } = useQueueActivitySuspenseQuery();
+  const queueActivity = data?.queueActivity as QueueActivity;
+
+  // TODO: Make it look nice
+  return (
+    <div className="flex gap-2 mb-4">
+      <div className="flex items-center gap-2">
+        <span className="font-semibold">Low Priority:</span>
+        <span>{queueActivity.low}</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="font-semibold">Medium Priority:</span>
+        <span>{queueActivity.medium}</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="font-semibold">High Priority:</span>
+        <span>{queueActivity.high}</span>
+      </div>
+    </div>
+  );
+};

--- a/app/frontend/src/features/import-jobs/components/queue-activity-display.tsx
+++ b/app/frontend/src/features/import-jobs/components/queue-activity-display.tsx
@@ -1,25 +1,40 @@
+import { Card } from 'react-bootstrap';
 import { QueueActivity } from '@/types/api';
 import { useQueueActivitySuspenseQuery } from '../api/get-queue-activity';
+
+type PriorityConfig = {
+  key: keyof QueueActivity;
+  label: string;
+  color: string;
+};
+
+const PRIORITIES: PriorityConfig[] = [
+  { key: 'high', label: 'High', color: '#b03a3a' },
+  { key: 'medium', label: 'Medium', color: '#c87d1a' },
+  { key: 'low', label: 'Low', color: '#2e7d5a' },
+];
 
 export const QueueActivityDisplay = () => {
   const { data } = useQueueActivitySuspenseQuery();
   const queueActivity = data?.queueActivity as QueueActivity;
 
-  // TODO: Make it look nice
   return (
-    <div className="flex gap-2 mb-4">
-      <div className="flex items-center gap-2">
-        <span className="font-semibold">Low Priority:</span>
-        <span>{queueActivity.low}</span>
-      </div>
-      <div className="flex items-center gap-2">
-        <span className="font-semibold">Medium Priority:</span>
-        <span>{queueActivity.medium}</span>
-      </div>
-      <div className="flex items-center gap-2">
-        <span className="font-semibold">High Priority:</span>
-        <span>{queueActivity.high}</span>
-      </div>
-    </div>
+    <Card className="mb-3 border-0 bg-light">
+      <Card.Body className="py-2 px-3">
+        <div className="d-flex align-items-center gap-4 flex-wrap">
+          <small className="fw-semibold text-muted text-nowrap">Queue Activity (all users):</small>
+          <div className="d-flex gap-3">
+            {PRIORITIES.map(({ key, label, color }) => (
+              <div key={key} className="d-flex align-items-center gap-2">
+                <span className="badge rounded-pill text-white" style={{ backgroundColor: color }}>
+                  {queueActivity[key]}
+                </span>
+                <small className="text-muted">{label} Priority</small>
+              </div>
+            ))}
+          </div>
+        </div>
+      </Card.Body>
+    </Card>
   );
 };

--- a/app/frontend/src/features/import-jobs/utils/import-jobs-list-column-defs.tsx
+++ b/app/frontend/src/features/import-jobs/utils/import-jobs-list-column-defs.tsx
@@ -25,14 +25,20 @@ export const columnDefs = [
     header: 'Status',
     cell: (info) => info.getValue(),
   }),
+  columnHelper.accessor('priority', {
+    header: 'Priority',
+    cell: (info) => info.getValue(),
+  }),
   columnHelper.accessor('createdAt', {
     header: 'Submitted At',
     cell: (info) => info.getValue() || 'Unknown',
   }),
-  columnHelper.accessor('user.email', {
+  columnHelper.accessor('user.uid', {
     header: 'Submitted By',
     cell: (info) => info.getValue() || 'Unknown',
   }),
+  // TODO: Show delete link for completed jobs only
+  // Otherwise display "Job not complete" and allow force delete for *admin users only*
   columnHelper.display({
     id: 'actions',
     header: 'Actions',

--- a/app/frontend/src/features/import-jobs/utils/import-jobs-list-column-defs.tsx
+++ b/app/frontend/src/features/import-jobs/utils/import-jobs-list-column-defs.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router';
-import { ImportJobSummary } from '@/types/api';
 import { createColumnHelper } from '@tanstack/react-table';
 import { Button } from 'react-bootstrap';
+import { ImportJobSummary } from '@/types/api';
 
 const columnHelper = createColumnHelper<ImportJobSummary>();
 
@@ -36,11 +36,11 @@ export const columnDefs = [
   columnHelper.display({
     id: 'actions',
     header: 'Actions',
-    cell: (props) => (
+    cell: ({ row, table }) => (
       <Button
         variant="outline-secondary"
         size="sm"
-        // onClick={() => props.table.options.meta?.removeRow(props.row.index)} // TODO
+        onClick={() => table.options.meta?.onDeleteRow?.(row.original)}
       >
         Delete
       </Button>

--- a/app/frontend/src/features/import-jobs/utils/import-jobs-list-column-defs.tsx
+++ b/app/frontend/src/features/import-jobs/utils/import-jobs-list-column-defs.tsx
@@ -2,8 +2,40 @@ import { Link } from 'react-router';
 import { createColumnHelper } from '@tanstack/react-table';
 import { Button } from 'react-bootstrap';
 import { ImportJobSummary } from '@/types/api';
+import { formatLocalDateTime } from '@/utils/format';
+import { User } from '@/types/api';
 
 const columnHelper = createColumnHelper<ImportJobSummary>();
+
+const renderDeleteButton = (
+  row: ImportJobSummary,
+  currentUser: User | undefined,
+  onDeleteRow?: (row: ImportJobSummary) => void,
+) => {
+  const onDelete = () => onDeleteRow?.(row);
+
+  if (row.complete) {
+    return (
+      <Button variant="outline-secondary" size="sm" onClick={onDelete}>
+        Delete
+      </Button>
+    );
+  }
+
+  return (
+    <div>
+      Job not complete
+      {currentUser?.isAdmin && (
+        <>
+          <br />
+          <Button variant="outline-secondary" size="sm" onClick={onDelete}>
+            Force delete
+          </Button>
+        </>
+      )}
+    </div>
+  );
+};
 
 export const columnDefs = [
   columnHelper.accessor('id', {
@@ -31,26 +63,22 @@ export const columnDefs = [
   }),
   columnHelper.accessor('createdAt', {
     header: 'Submitted At',
-    cell: (info) => info.getValue() || 'Unknown',
+    cell: (info) => formatLocalDateTime(info.getValue() || '') || 'Unknown',
   }),
   columnHelper.accessor('user.uid', {
     header: 'Submitted By',
     cell: (info) => info.getValue() || 'Unknown',
   }),
-  // TODO: Show delete link for completed jobs only
-  // Otherwise display "Job not complete" and allow force delete for *admin users only*
   columnHelper.display({
     id: 'actions',
     header: 'Actions',
-    cell: ({ row, table }) => (
-      <Button
-        variant="outline-secondary"
-        size="sm"
-        onClick={() => table.options.meta?.onDeleteRow?.(row.original)}
-      >
-        Delete
-      </Button>
-    ),
     enableSorting: false,
+    cell: ({ row, table }) => {
+      const job = row.original;
+      const currentUser = table.options.meta?.currentUser;
+      const onDelete = () => table.options.meta?.onDeleteRow?.(job);
+
+      return renderDeleteButton(job, currentUser, onDelete);
+    },
   }),
 ];

--- a/app/frontend/src/features/import-jobs/utils/import-jobs-list-column-defs.tsx
+++ b/app/frontend/src/features/import-jobs/utils/import-jobs-list-column-defs.tsx
@@ -1,0 +1,50 @@
+import { Link } from 'react-router';
+import { ImportJob } from '@/types/api';
+import { createColumnHelper } from '@tanstack/react-table';
+import Button from 'react-bootstrap/esm/Button';
+
+const columnHelper = createColumnHelper<ImportJob>();
+
+export const columnDefs = [
+  columnHelper.accessor('id', {
+    header: 'Import Job ID',
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor('name', {
+    header: 'Name',
+    cell: ({ row }) => (
+      <Link
+        to={{ pathname: `/import-jobs/${row.original.id}` }}
+        className="link-underline link-underline-opacity-0 link-underline-opacity-75-hover"
+      >
+        <span>{row.original.name}</span>
+      </Link>
+    ),
+  }),
+  columnHelper.accessor('status', {
+    header: 'Status',
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor('createdAt', {
+    header: 'Submitted At',
+    cell: (info) => info.getValue() || 'Unknown',
+  }),
+  // columnHelper.accessor('createdBy', {
+  //   header: 'Submitted By',
+  //   cell: (info) => info.getValue() || 'Unknown',
+  // }), // TODO: get the user who submitted the import job
+  columnHelper.display({
+    id: 'actions',
+    header: 'Actions',
+    cell: (props) => (
+      <Button
+        variant="outline-secondary"
+        size="sm"
+        // onClick={() => props.table.options.meta?.removeRow(props.row.index)} // TODO
+      >
+        Delete
+      </Button>
+    ),
+    enableSorting: false,
+  }),
+];

--- a/app/frontend/src/features/import-jobs/utils/import-jobs-list-column-defs.tsx
+++ b/app/frontend/src/features/import-jobs/utils/import-jobs-list-column-defs.tsx
@@ -29,10 +29,10 @@ export const columnDefs = [
     header: 'Submitted At',
     cell: (info) => info.getValue() || 'Unknown',
   }),
-  // columnHelper.accessor('createdBy', {
-  //   header: 'Submitted By',
-  //   cell: (info) => info.getValue() || 'Unknown',
-  // }), // TODO: get the user who submitted the import job
+  columnHelper.accessor('user.email', {
+    header: 'Submitted By',
+    cell: (info) => info.getValue() || 'Unknown',
+  }),
   columnHelper.display({
     id: 'actions',
     header: 'Actions',

--- a/app/frontend/src/features/import-jobs/utils/import-jobs-list-column-defs.tsx
+++ b/app/frontend/src/features/import-jobs/utils/import-jobs-list-column-defs.tsx
@@ -1,9 +1,9 @@
 import { Link } from 'react-router';
-import { ImportJob } from '@/types/api';
+import { ImportJobSummary } from '@/types/api';
 import { createColumnHelper } from '@tanstack/react-table';
-import Button from 'react-bootstrap/esm/Button';
+import { Button } from 'react-bootstrap';
 
-const columnHelper = createColumnHelper<ImportJob>();
+const columnHelper = createColumnHelper<ImportJobSummary>();
 
 export const columnDefs = [
   columnHelper.accessor('id', {

--- a/app/frontend/src/lib/api-client.ts
+++ b/app/frontend/src/lib/api-client.ts
@@ -1,5 +1,26 @@
 const BASE_URL = '/api/v2';
 
+export type ApiErrorResponse = {
+  errors?: Record<string, string[]>;
+  error?: string;
+  message?: string;
+  [key: string]: unknown;
+};
+
+// Error thrown for any non-2xx response. Carries the HTTP status
+// and the parsed JSON body
+export class ApiError extends Error {
+  readonly status: number;
+  readonly response: ApiErrorResponse | null;
+
+  constructor(status: number, statusText: string, response: ApiErrorResponse | null) {
+    super(response?.message ?? response?.error ?? statusText);
+    this.name = 'ApiError';
+    this.status = status;
+    this.response = response;
+  }
+}
+
 async function request<T>(endpoint: string, options?: RequestInit): Promise<T> {
   // When uploading files, the body will be a FormData instance, which automatically sets the correct Content-Type header.
   const isFormData = options?.body instanceof FormData;
@@ -17,12 +38,8 @@ async function request<T>(endpoint: string, options?: RequestInit): Promise<T> {
   const response = await fetch(`${BASE_URL}${endpoint}`, config);
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => null);
-
-    // Throw the parsed error data so React Query can access it
-    const error = new Error(response.statusText);
-    error.response = errorData;
-    throw error;
+    const errorData: ApiErrorResponse | null = await response.json().catch(() => null);
+    throw new ApiError(response.status, response.statusText, errorData);
   }
 
   // Handle cases where the response has no content (like delete operations)

--- a/app/frontend/src/lib/api-client.ts
+++ b/app/frontend/src/lib/api-client.ts
@@ -1,11 +1,14 @@
 const BASE_URL = '/api/v2';
 
 async function request<T>(endpoint: string, options?: RequestInit): Promise<T> {
+  // When uploading files, the body will be a FormData instance, which automatically sets the correct Content-Type header.
+  const isFormData = options?.body instanceof FormData;
+
   const config: RequestInit = {
     ...options,
     headers: {
-      'Content-Type': 'application/json',
-      'Accept': 'application/json',
+      ...(isFormData ? {} : { 'Content-Type': 'application/json' }),
+      Accept: 'application/json',
       ...options?.headers,
     },
     credentials: 'include',
@@ -15,7 +18,7 @@ async function request<T>(endpoint: string, options?: RequestInit): Promise<T> {
 
   if (!response.ok) {
     const errorData = await response.json().catch(() => null);
-    
+
     // Throw the parsed error data so React Query can access it
     const error = new Error(response.statusText);
     error.response = errorData;
@@ -31,27 +34,25 @@ async function request<T>(endpoint: string, options?: RequestInit): Promise<T> {
 }
 
 export const api = {
-  get: <T>(endpoint: string) =>
-    request<T>(endpoint, { method: 'GET' }),
+  get: <T>(endpoint: string) => request<T>(endpoint, { method: 'GET' }),
 
   post: <T>(endpoint: string, data?: unknown) =>
     request<T>(endpoint, {
       method: 'POST',
-      body: JSON.stringify(data)
+      body: data instanceof FormData ? data : JSON.stringify(data),
     }),
 
   put: <T>(endpoint: string, data?: unknown) =>
     request<T>(endpoint, {
       method: 'PUT',
-      body: JSON.stringify(data)
+      body: JSON.stringify(data),
     }),
 
   patch: <T>(endpoint: string, data?: unknown) =>
     request<T>(endpoint, {
       method: 'PATCH',
-      body: JSON.stringify(data)
+      body: JSON.stringify(data),
     }),
 
-  delete: <T>(endpoint: string) =>
-    request<T>(endpoint, { method: 'DELETE' }),
+  delete: <T>(endpoint: string) => request<T>(endpoint, { method: 'DELETE' }),
 };

--- a/app/frontend/src/lib/api-client.ts
+++ b/app/frontend/src/lib/api-client.ts
@@ -1,4 +1,4 @@
-const BASE_URL = '/api/v2';
+export const BASE_URL = '/api/v2';
 
 export type ApiErrorResponse = {
   errors?: Record<string, string[]>;

--- a/app/frontend/src/lib/react-query.ts
+++ b/app/frontend/src/lib/react-query.ts
@@ -1,5 +1,6 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 import { UseMutationOptions, DefaultOptions } from '@tanstack/react-query';
+import { ApiError } from '@/lib/api-client';
 
 export const queryConfig = {
   queries: {
@@ -9,8 +10,9 @@ export const queryConfig = {
   },
 } satisfies DefaultOptions;
 
-export type ApiFnReturnType<FnType extends (...args: any) => Promise<any>> =
-  Awaited<ReturnType<FnType>>;
+export type ApiFnReturnType<FnType extends (...args: any) => Promise<any>> = Awaited<
+  ReturnType<FnType>
+>;
 
 // Extracts all React Query options (like enabled, onSuccess, etc.) EXCEPT queryKey and queryFn
 export type QueryConfig<T extends (...args: any[]) => any> = Omit<
@@ -18,10 +20,5 @@ export type QueryConfig<T extends (...args: any[]) => any> = Omit<
   'queryKey' | 'queryFn'
 >;
 
-export type MutationConfig<
-  MutationFnType extends (...args: any) => Promise<any>,
-> = UseMutationOptions<
-  ApiFnReturnType<MutationFnType>,
-  Error,
-  Parameters<MutationFnType>[0]
->;
+export type MutationConfig<MutationFnType extends (...args: any) => Promise<any>> =
+  UseMutationOptions<ApiFnReturnType<MutationFnType>, ApiError, Parameters<MutationFnType>[0]>;

--- a/app/frontend/src/types/api.ts
+++ b/app/frontend/src/types/api.ts
@@ -51,6 +51,7 @@ export interface ImportJobSummary {
   priority: string;
   status: string;
   createdAt: string;
+  complete: boolean;
   user: {
     uid: string;
     email: string;
@@ -84,7 +85,7 @@ export interface DigitalObjectImportSummary {
 
 export interface DigitalObjectImport extends DigitalObjectImportSummary {
   importJobName: string;
-  digitalObjectData: any;
+  digitalObjectData: string;
   digitalObjectErrors: string[];
   prerequisiteCsvRowNumbers: number[];
 }

--- a/app/frontend/src/types/api.ts
+++ b/app/frontend/src/types/api.ts
@@ -90,6 +90,13 @@ export interface DigitalObjectImport extends DigitalObjectImportSummary {
   prerequisiteCsvRowNumbers: number[];
 }
 
+export interface Pagination {
+  currentPage: number;
+  perPage: number;
+  totalPages: number;
+  totalCount: number;
+}
+
 /* 
 Payload types
 */

--- a/app/frontend/src/types/api.ts
+++ b/app/frontend/src/types/api.ts
@@ -75,6 +75,7 @@ export interface DigitalObjectImportSummary {
   id: number;
   importJobId: number;
   status: string;
+  csvRowNumber: number;
   createdAt: string;
   updatedAt: string;
 }

--- a/app/frontend/src/types/api.ts
+++ b/app/frontend/src/types/api.ts
@@ -62,6 +62,12 @@ export interface ImportJob {
   };
 }
 
+export interface QueueActivity {
+  low: number;
+  medium: number;
+  high: number;
+}
+
 /* 
 Payload types
 */

--- a/app/frontend/src/types/api.ts
+++ b/app/frontend/src/types/api.ts
@@ -56,6 +56,10 @@ export interface ImportJob {
   pendingCount: number;
   createdAt: string;
   updatedAt: string;
+  user: {
+    email: string;
+    fullName: string;
+  };
 }
 
 /* 

--- a/app/frontend/src/types/api.ts
+++ b/app/frontend/src/types/api.ts
@@ -45,6 +45,18 @@ export interface XmlDatastream {
   xmlTranslation: string;
 }
 
+export interface ImportJob {
+  id: number;
+  name: string;
+  priority: string;
+  pathToCsvFile: string;
+  status: string;
+  successCount: number;
+  failureCount: number;
+  pendingCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
 
 /* 
 Payload types

--- a/app/frontend/src/types/api.ts
+++ b/app/frontend/src/types/api.ts
@@ -71,6 +71,14 @@ export interface QueueActivity {
   high: number;
 }
 
+export interface DigitalObjectImportSummary {
+  id: number;
+  importJobId: number;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 /* 
 Payload types
 */

--- a/app/frontend/src/types/api.ts
+++ b/app/frontend/src/types/api.ts
@@ -80,6 +80,12 @@ export interface DigitalObjectImportSummary {
   updatedAt: string;
 }
 
+export interface DigitalObjectImport extends DigitalObjectImportSummary {
+  digitalObjectData: any;
+  digitalObjectErrors: string[];
+  prerequisiteCsvRowNumbers: number[];
+}
+
 /* 
 Payload types
 */

--- a/app/frontend/src/types/api.ts
+++ b/app/frontend/src/types/api.ts
@@ -45,21 +45,24 @@ export interface XmlDatastream {
   xmlTranslation: string;
 }
 
-export interface ImportJob {
+export interface ImportJobSummary {
   id: number;
   name: string;
   priority: string;
-  pathToCsvFile: string;
   status: string;
-  successCount: number;
-  failureCount: number;
-  pendingCount: number;
   createdAt: string;
-  updatedAt: string;
   user: {
     email: string;
     fullName: string;
   };
+}
+
+export interface ImportJob extends ImportJobSummary {
+  pathToCsvFile: string;
+  pendingCount: number;
+  successCount: number;
+  failureCount: number;
+  updatedAt: string;
 }
 
 export interface QueueActivity {

--- a/app/frontend/src/types/api.ts
+++ b/app/frontend/src/types/api.ts
@@ -60,6 +60,7 @@ export interface ImportJobSummary {
 
 export interface ImportJob extends ImportJobSummary {
   pathToCsvFile: string;
+  restoreArchivedS3ObjectsForNewAssets: boolean;
   pendingCount: number;
   successCount: number;
   failureCount: number;

--- a/app/frontend/src/types/api.ts
+++ b/app/frontend/src/types/api.ts
@@ -52,6 +52,7 @@ export interface ImportJobSummary {
   status: string;
   createdAt: string;
   user: {
+    uid: string;
     email: string;
     fullName: string;
   };
@@ -81,6 +82,7 @@ export interface DigitalObjectImportSummary {
 }
 
 export interface DigitalObjectImport extends DigitalObjectImportSummary {
+  importJobName: string;
   digitalObjectData: any;
   digitalObjectErrors: string[];
   prerequisiteCsvRowNumbers: number[];

--- a/app/frontend/src/types/react-table.d.ts
+++ b/app/frontend/src/types/react-table.d.ts
@@ -1,9 +1,11 @@
 import '@tanstack/react-table';
+import { User } from '@/types/api';
 
 // Extends the TableMeta interface to include an optional onDeleteRow function
 // https://tanstack.com/table/v8/docs/api/core/table#meta
 declare module '@tanstack/react-table' {
   interface TableMeta<TData> {
     onDeleteRow?: (row: TData) => void;
+    currentUser?: User;
   }
 }

--- a/app/frontend/src/types/react-table.d.ts
+++ b/app/frontend/src/types/react-table.d.ts
@@ -1,0 +1,9 @@
+import '@tanstack/react-table';
+
+// Extends the TableMeta interface to include an optional onDeleteRow function
+// https://tanstack.com/table/v8/docs/api/core/table#meta
+declare module '@tanstack/react-table' {
+  interface TableMeta<TData> {
+    onDeleteRow?: (row: TData) => void;
+  }
+}

--- a/app/frontend/src/utils/format.ts
+++ b/app/frontend/src/utils/format.ts
@@ -1,0 +1,19 @@
+// Converts an ISO date string to local time and formats it as "YYYY-MM-DD HH:mm:ss"
+export const formatLocalDateTime = (isoString: string): string => {
+  const date = new Date(isoString);
+
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+
+  const parts = formatter.formatToParts(date);
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? '';
+
+  return `${get('year')}-${get('month')}-${get('day')} ${get('hour')}:${get('minute')}:${get('second')}`;
+};

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -12,6 +12,7 @@ class Ability
       can :manage, User
       can :manage, PublishTarget
       can :manage, XmlDatastream
+      can :manage, ImportJob
 
       # Admins cannot change their own is_admin status as a safe guard
       cannot :update_is_admin, User, id: user.id
@@ -22,6 +23,9 @@ class Ability
 
       # Only Hyacinth admins can update project permissions
       cannot :update_project_permissions, User
+
+      # Non-admin users can only view and delete their own import jobs
+      can [:index, :show, :destroy], ImportJob, user_id: user.id
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -177,6 +177,8 @@ Rails.application.routes.draw do
       resources :publish_targets, only: [:index, :show, :create, :update, :destroy], param: :string_key
 
       resources :xml_datastreams, only: [:index, :show, :create, :update], param: :string_key
+
+      resources :import_jobs, only: [:create]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,7 +178,7 @@ Rails.application.routes.draw do
 
       resources :xml_datastreams, only: [:index, :show, :create, :update], param: :string_key
 
-      resources :import_jobs, only: [:create]
+      resources :import_jobs, only: [:index, :create, :show], param: :id
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -185,6 +185,11 @@ Rails.application.routes.draw do
           get 'queue_activity'
         end
 
+        member do
+          get 'download_original_csv'
+          get 'download_csv_without_successful_rows'
+        end
+
         resources :digital_object_imports, only: [:index, :show]
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,9 +178,10 @@ Rails.application.routes.draw do
 
       resources :xml_datastreams, only: [:index, :show, :create, :update], param: :string_key
 
-      resources :import_jobs, only: [:index, :create, :show], param: :id do
+      resources :import_jobs, only: [:index, :create, :show, :destroy], param: :id do
         collection do
           post 'validate'
+          get 'queue_activity'
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
     resources :digital_object_imports, only: [:index, :show]
   end
 
+  # ? Should this be deleted since it's the same resource as the one nested under import_jobs?
   resources :digital_object_imports, only: [:index, :show]
 
   resources :digital_objects do
@@ -183,6 +184,8 @@ Rails.application.routes.draw do
           post 'validate'
           get 'queue_activity'
         end
+
+        resources :digital_object_imports, only: [:index, :show]
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,7 +178,11 @@ Rails.application.routes.draw do
 
       resources :xml_datastreams, only: [:index, :show, :create, :update], param: :string_key
 
-      resources :import_jobs, only: [:index, :create, :show], param: :id
+      resources :import_jobs, only: [:index, :create, :show], param: :id do
+        collection do
+          post 'validate'
+        end
+      end
     end
   end
 

--- a/lib/hyacinth/utils/csv_import_export_utils.rb
+++ b/lib/hyacinth/utils/csv_import_export_utils.rb
@@ -156,7 +156,7 @@ class Hyacinth::Utils::CsvImportExportUtils
     import_job = ImportJob.new(name: import_filename, user: user, priority: priority, restore_archived_s3_objects_for_new_assets: restore_archived_s3_objects_for_new_assets)
 
     # First, run through the CSV and do some quick validations
-    validate_import_job_csv_data(csv_data_string, user, import_job)
+    # validate_import_job_csv_data(csv_data_string, user, import_job)
 
     # Assuming there were no validation errors, run through the CSV data again and do an import for real
     unless import_job.errors.any?

--- a/lib/hyacinth/utils/csv_import_export_utils.rb
+++ b/lib/hyacinth/utils/csv_import_export_utils.rb
@@ -156,7 +156,7 @@ class Hyacinth::Utils::CsvImportExportUtils
     import_job = ImportJob.new(name: import_filename, user: user, priority: priority, restore_archived_s3_objects_for_new_assets: restore_archived_s3_objects_for_new_assets)
 
     # First, run through the CSV and do some quick validations
-    # validate_import_job_csv_data(csv_data_string, user, import_job)
+    validate_import_job_csv_data(csv_data_string, user, import_job)
 
     # Assuming there were no validation errors, run through the CSV data again and do an import for real
     unless import_job.errors.any?


### PR DESCRIPTION
# Ticket [HYACINTH-1190](https://columbiauniversitylibraries.atlassian.net/browse/HYACINTH-1190)

## Overview
This PR adds a new API and UI for Import Jobs and their underlying Digital Object Imports. As with previous tickets in this migration, the old API and UI are preserved and the new UI is only visible under the `/ui/v2` route, where React is mounted.

## Backend
As with previous PRs in this migration, the new controllers use JSON: incoming request keys are transformed to snake_case and response keys are converted to camelCase. The index and show responses differ slightly to avoid sending data the UI doesn't use. The more significant changes are listed below.

### Import Jobs Controller
1. Enhanced permissions - Previously, non-admins saw only their own import jobs in the list but they could still view the details of other users' import jobs and the digital object imports belonging to those jobs.
2. Separated the validate-only and submit actions - Previously the mode was determined by a param (e.g. `params[:submit] == 'validate'`); they are now two distinct endpoints. This also fits the new `restoreArchivedS3ObjectsForNewAssets` value, which isn't passed for the validate-only action.
3. Split queue status out of the index action - Import job queue data now lives in its own endpoint so it can be cached and retrieved independently. Since the index action is paginated, keeping the two coupled meant fetching the queue status more often than necessary.

### Digital Object Imports Controller
1. Scoped lookups to the parent import job - Retrieving a digital object import now uses the import job ID as well, rather than the import's ID alone.
2. Enhanced permissions - Before returning a digital object import, we now also verify that the user can access its associated import job.

### Pagination
Both index actions use Kaminari to build the `pagination_data` object.

## Frontend

### New routes
1. `ui/v2/import-jobs` - renders a list of all import jobs (for admins) or the import jobs created by the current non-admin user.
2. `ui/v2/import-jobs/new` - renders a form to upload a CSV file with the option to either submit or validate it.
3. `ui/v2/import-jobs/:importJobId` - renders import job details, CSV download links and counts of pending/successful/failed row imports, with a link to view all object imports.
    1. `ui/v2/import-jobs/:importJobId/digital-object-imports` - displays a paginated list of all digital object imports for the import job, with the option to filter by status.
    2. `ui/v2/import-jobs/:importJobId/digital-object-imports/:digitalObjectImportId` - displays digital object import details and lists validation errors, if present.

### Notable changes
1. Modified the API client to handle file uploads via form data (previously it handled JSON only) and added an `ApiError` class (extends `Error`) that carries the response status and JSON body for better type handling.
2. The digital object import view now uses the Monaco editor in read-only mode to display the digital object data (previously rendered as a plain string) and includes a copy-to-clipboard button.
3. Added optional server-side pagination to the reusable `TableBuilder` component. Because sorting would only apply to the current page, I disabled it for paginated tables as a temporary workaround. We can discuss later whether any columns on the import jobs or digital object imports pages should be sortable.
4. The CSV download helpers don't use the shared API client, since they return files rather than JSON. Downloads currently happen on a single page, so it's best to keep the API client limited to JSON and form data.

### Prettier
I included a `settings.json` with the Prettier configuration we use for ATC. Formatting the entire repo would add too many changes to an already large PR so I haven't formatted any files outside of those relevant to the migration.

### Tests
Tests will be added separately once the API and UI are finalized.