### PR TITLE
HYACINTH-1215 and HYACINTH-1214

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -35,7 +35,10 @@ class ProjectsController < ApplicationController
 
   # GET /projects/new
   def new
-    @project = Project.new
+    @project = Project.new(
+      default_storage_type: HYACINTH[:default_storage_type] || Hyacinth::Storage::STORAGE_SCHEMES.first,
+      default_access_storage_type: HYACINTH[:default_access_storage_type] || Hyacinth::Storage::STORAGE_SCHEMES.first,
+    )
   end
 
   # GET /projects/1/edit/:type

--- a/config/templates/hyacinth.template.yml
+++ b/config/templates/hyacinth.template.yml
@@ -2,6 +2,8 @@ development:
   solr_url: http://localhost:8983/solr/hyacinth
   default_pid_generator_namespace: cul
   digital_object_data_directory: <%= Rails.root.join('tmp', 'development', 'data') %>
+  default_storage_type: 'file' # 's3' is another option
+  default_access_storage_type: 'file' # 's3' is another option
   default_resource_storage_locations:
     main:
       file:
@@ -35,6 +37,8 @@ test:
   solr_url: http://localhost:9983/solr/hyacinth
   default_pid_generator_namespace: cul
   digital_object_data_directory: <%= Rails.root.join('tmp', 'test', 'data') %>
+  default_storage_type: 'file' # 's3' is another option
+  default_access_storage_type: 'file' # 's3' is another option
   default_resource_storage_locations:
     main:
       file:

--- a/lib/hyacinth/utils/path_utils.rb
+++ b/lib/hyacinth/utils/path_utils.rb
@@ -3,17 +3,17 @@ class Hyacinth::Utils::PathUtils
     # uuid format: "cc092507-6baf-4c81-9cba-ea97cc0b30f2"
     # equivalent pairtree format /cc/09/25/07/
     # NOTE: This will result in the creation of a maximum of 4,228,250,625 pairtree intermediate directories (255^4).
-    # [uuid[0, 2], uuid[2, 2], uuid[4, 2], uuid[6, 2]]
+    [uuid[0, 2], uuid[2, 2], uuid[4, 2], uuid[6, 2]]
+  end
 
-    # Rather than going four levels deep in the code above, we're going to go six directory levels deep to maintain
-    # compatibility with an earlier version of Hyacinth.  We probably don't need that many levels, and it creates
-    # a lot of extra intermediate directories, but compatibility is important.
-    # Later on, if we switch to four directory levels deep, we can write a script to move files around appropriately.
-
+  # This six depth pairtree method only exists to maintain compatibility compatibility with an earlier version of
+  # Hyacinth, but in the long run we want to only use the uuid_pairtree() method instead (which is 4 levels deep).
+  # We don't need to go six levels deep, and it creates a lot of extra intermediate directories.
+  # Later on, when we switch to four directory levels deep, we can write a script to move files around appropriately.
+  def self.legacy_six_depth_uuid_pairtree(uuid)
     # uuid format: "cc092507-6baf-4c81-9cba-ea97cc0b30f2"
     # equivalent pairtree format /cc/09/25/07/6b/af/
-    # NOTE: This will result in the creation of a maximum of 274,941,996,890,625
-    # pairtree intermediate directories (255^6).
+    # NOTE: This will result in the creation of a maximum of 274,941,996,890,625 pairtree intermediate directories (255^6).
     [uuid[0, 2], uuid[2, 2], uuid[4, 2], uuid[6, 2], uuid[9, 2], uuid[11, 2]]
   end
 
@@ -39,6 +39,8 @@ class Hyacinth::Utils::PathUtils
   end
 
   def self.data_directory_path_for_uuid(uuid)
-    File.join(HYACINTH[:digital_object_data_directory], uuid_pairtree(uuid), uuid)
+    # TODO: Eventually change the call to `legacy_six_depth_uuid_pairtree` to a call to `uuid_pairtree`
+    # (but this will require some rearranging of filesystem files).
+    File.join(HYACINTH[:digital_object_data_directory], legacy_six_depth_uuid_pairtree(uuid), uuid)
   end
 end

--- a/spec/lib/hyacinth/utils/path_utils_spec.rb
+++ b/spec/lib/hyacinth/utils/path_utils_spec.rb
@@ -11,25 +11,25 @@ RSpec.describe Hyacinth::Utils::PathUtils do
 
     it 'works as expected for a simple extension' do
       expect(described_class.relative_resource_file_path_for_uuid(uuid, suffix, extension)).to eq(
-        '32/29/41/4b/50/be/3229414b-50be-4137-a360-fa97f043e2f5/3229414b-50be-4137-a360-fa97f043e2f5-access.tiff'
+        '32/29/41/4b/3229414b-50be-4137-a360-fa97f043e2f5/3229414b-50be-4137-a360-fa97f043e2f5-access.tiff'
       )
     end
 
     it 'works as expected when a leading period is provided with the extension' do
       expect(described_class.relative_resource_file_path_for_uuid(uuid, suffix, extension_with_leading_period)).to eq(
-        '32/29/41/4b/50/be/3229414b-50be-4137-a360-fa97f043e2f5/3229414b-50be-4137-a360-fa97f043e2f5-access.tiff'
+        '32/29/41/4b/3229414b-50be-4137-a360-fa97f043e2f5/3229414b-50be-4137-a360-fa97f043e2f5-access.tiff'
       )
     end
 
     it 'downcases file extensions' do
       expect(described_class.relative_resource_file_path_for_uuid(uuid, suffix, extension_with_capital_letters)).to eq(
-        '32/29/41/4b/50/be/3229414b-50be-4137-a360-fa97f043e2f5/3229414b-50be-4137-a360-fa97f043e2f5-access.tiff'
+        '32/29/41/4b/3229414b-50be-4137-a360-fa97f043e2f5/3229414b-50be-4137-a360-fa97f043e2f5-access.tiff'
       )
     end
 
     it 'cleans file extensions to only allow periods, letters a-z and A-Z, and numbers' do
       expect(described_class.relative_resource_file_path_for_uuid(uuid, suffix, extension_with_invalid_chars)).to eq(
-        '32/29/41/4b/50/be/3229414b-50be-4137-a360-fa97f043e2f5/3229414b-50be-4137-a360-fa97f043e2f5-access.jpg'
+        '32/29/41/4b/3229414b-50be-4137-a360-fa97f043e2f5/3229414b-50be-4137-a360-fa97f043e2f5-access.jpg'
       )
     end
   end

--- a/spec/unit/lib_hyacinth_utils/path_utils_spec.rb
+++ b/spec/unit/lib_hyacinth_utils/path_utils_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Hyacinth::Utils::PathUtils do
-
   describe "uuid methods" do
     let(:uuid) { 'cc092507-6baf-4c81-9cba-ea97cc0b30f2' }
-    let(:uuid_pair_tree) { ['cc', '09', '25', '07', '6b', 'af'] }
+    let(:uuid_pair_tree) { ['cc', '09', '25', '07'] }
+    let(:legacy_six_depth_uuid_pair_tree) { ['cc', '09', '25', '07', '6b', 'af'] }
 
     context ".uuid_pairtree" do
       it "returns the expected value" do
@@ -14,10 +14,41 @@ RSpec.describe Hyacinth::Utils::PathUtils do
 
     context ".data_file_path_for_uuid" do
       it "returns the expected path" do
-        expect(described_class.data_file_path_for_uuid(uuid)).to eq(File.join(HYACINTH[:digital_object_data_directory], uuid_pair_tree.join('/'), uuid, uuid + '.json'))
+        expect(described_class.data_file_path_for_uuid(uuid)).to eq(File.join(HYACINTH[:digital_object_data_directory], legacy_six_depth_uuid_pair_tree.join('/'), uuid, uuid + '.json'))
       end
     end
 
-  end
+    context ".legacy_six_depth_uuid_pairtree" do
+      it "returns the expected value" do
+        expect(described_class.legacy_six_depth_uuid_pairtree(uuid)).to eq(legacy_six_depth_uuid_pair_tree)
+      end
+    end
 
+    context ".relative_resource_directory_path_for_uuid" do
+      it "returns the expected path" do
+        expect(described_class.relative_resource_directory_path_for_uuid(uuid)).to eq(File.join(uuid_pair_tree.join('/'), uuid))
+      end
+
+      it "returns the expected path, and only has one period before the extension even if the caller supplies an extension value that starts with a period" do
+        expect(
+          described_class.relative_resource_directory_path_for_uuid(uuid)
+        ).to eq(File.join(uuid_pair_tree.join('/'), uuid))
+      end
+    end
+
+    context ".relative_resource_file_path_for_uuid" do
+      let(:suffix) { '-main' }
+      let(:extension) { 'png' }
+      let(:extension_that_starts_with_period) { ".#{extension}" }
+      it "returns the expected path" do
+        expect(described_class.relative_resource_file_path_for_uuid(uuid, suffix, extension)).to eq(File.join(uuid_pair_tree.join('/'), uuid, uuid + suffix + '.' + extension))
+      end
+
+      it "returns the expected path, and only has one period before the extension even if the caller supplies an extension value that starts with a period" do
+        expect(
+          described_class.relative_resource_file_path_for_uuid(uuid, suffix, extension_that_starts_with_period)
+        ).to eq(File.join(uuid_pair_tree.join('/'), uuid, uuid + suffix + '.' + extension))
+      end
+    end
+  end
 end


### PR DESCRIPTION
- HYACINTH-1215: Hyacinth should use a 4-level deep pair tree path instead of a 6-level deep pair tree path for resources
- HYACINTH-1214: Make default_storage_type and default_access_storage_type configurable via hyacinth.yml config file